### PR TITLE
Land community PR #34: sequence_vec benchmark + observe-path stack-safety regression test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,7 @@ harness = false
 [[bench]]
 name = "f_perf"
 harness = false
+
+[[bench]]
+name = "sequence_vec"
+harness = false

--- a/benches/sequence_vec.rs
+++ b/benches/sequence_vec.rs
@@ -1,0 +1,29 @@
+//! Benchmark for large sequences of simple observations.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use fugue::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+fn benchmark_stack_overflow_model(c: &mut Criterion) {
+    let n = 1_000usize;
+
+    c.bench_function("stack_overflow_model/sequence_vec", |b| {
+        b.iter(|| {
+            let models: Vec<Model<bool>> = (0..n)
+                .map(|i| sample(addr!("coin", i), Bernoulli::new(0.5).unwrap()))
+                .collect();
+            let model = sequence_vec(models);
+            let mut rng = StdRng::seed_from_u64(42);
+            let handler = runtime::interpreters::PriorHandler {
+                rng: &mut rng,
+                trace: runtime::trace::Trace::default(),
+            };
+            let (result, _trace) = runtime::handler::run(handler, model);
+            black_box(result.len());
+        })
+    });
+}
+
+criterion_group!(stack_overflow_benches, benchmark_stack_overflow_model);
+criterion_main!(stack_overflow_benches);

--- a/src/runtime/handler.rs
+++ b/src/runtime/handler.rs
@@ -287,4 +287,30 @@ mod tests {
             .join()
             .expect("deep model interpretation overflowed the stack");
     }
+
+    // Companion regression from PR #34: the same stack-safety guarantee through
+    // the `sequence_vec` + `observe` path (the deep test above covers
+    // sample+bind). 100k observations interpreted through `sequence_vec` must
+    // complete without overflowing the stack.
+    #[test]
+    fn run_handles_large_observe_sequence() {
+        use crate::core::model::{observe, sequence_vec};
+
+        let n = 100_000usize;
+        let models: Vec<Model<()>> = (0..n)
+            .map(|i| observe(addr!("obs", i), Bernoulli::new(0.5).unwrap(), true))
+            .collect();
+        let model = sequence_vec(models).map(|_| ());
+
+        let mut rng = StdRng::seed_from_u64(123);
+        let (_a, trace) = crate::runtime::handler::run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            model,
+        );
+
+        assert!(trace.log_likelihood.is_finite());
+    }
 }


### PR DESCRIPTION
Lands the still-applicable parts of #34 by @brendanashworth, rebased onto post-audit `main`. Closes #34.

## Background

#34 (December 2025) correctly diagnosed and fixed a stack overflow: `run` recursed once per effectful node, and the old `sequence_vec` built a left-associated `zip` tower, so large `observe` sequences blew the stack. The July 2026 audit independently confirmed the same defect (finding FG-19), and the remediation merged in #36 fixed it with an iterative trampoline in `run` plus a continuation-threaded `sequence_vec` — which unfortunately left #34 in conflict with `main`.

## What this PR keeps from #34

The parts that remain novel after #36, with @brendanashworth's commit authorship preserved:

- **`benches/sequence_vec.rs`** — criterion benchmark for large `observe` sequences through `sequence_vec` (the benchmark that quantified the original fix at ~97% faster for n=1,000).
- **`run_handles_large_observe_sequence`** — 100k-observation regression test through the `sequence_vec` + `observe` path. The existing FG-19 test covers deep `sample`+`bind`; this covers the other interpretation path that #34 originally protected.

## Verification

- Full suite green locally (`cargo test --all-features`): all lib tests + 164 doctests pass, including the new regression test (0.10s).
- `cargo bench --bench sequence_vec --no-run` compiles clean with `RUSTFLAGS=-Dwarnings`.
- `cargo clippy --all-targets --all-features` and `cargo fmt --check` clean.

Thanks @brendanashworth for finding and fixing this before the audit did — the first community fix to fugue's interpreter core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEAKcbnLVP8iSXub2Pqor2
