### PR TITLE
release: fugue-ppl 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ For the initial 0.1.0 release notes, see `.github/CHANGELOG.md`.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-13
+
 The entries below summarize a full-crate audit remediation (170 findings,
 tracked as `FG-01` .. `FG-64` in the project's audit record) organized by
 area. Each bullet range names the finding IDs addressed in that area; a later

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "fugue-ppl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cargo-llvm-cov",
  "clap 4.5.45",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-ppl"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 # Finding FG-51: the README previously claimed "1.70+" with nothing pinning or
 # verifying it. Verified empirically against real toolchains (not just

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Fugue is 0.1.x: pre-1.0, actively developed, with no SemVer stability guarantee 
 
 ```toml
 [dependencies]
-fugue-ppl = "0.1.0"
+fugue-ppl = "0.2.0"
 ```
 
 ### Quickstart
@@ -133,12 +133,12 @@ Licensed under the [MIT License](LICENSE).
 If you use Fugue in your research, please cite:
 
 ```bibtex
-@software{fugue2025,
+@software{fugue2026,
   title = {Fugue: Monadic Probabilistic Programming for Rust},
   author = {Alexander Nodeland},
   url = {https://github.com/alexnodeland/fugue},
-  version = {0.1.0},
-  year = {2025}
+  version = {0.2.0},
+  year = {2026}
 }
 ```
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -34,7 +34,7 @@ Add Fugue to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fugue-ppl = "0.1.0"
+fugue-ppl = "0.2.0"
 rand = "0.8"  # For random number generation
 ```
 
@@ -44,7 +44,7 @@ Add Fugue to your existing `Cargo.toml`:
 
 ```toml
 [dependencies]
-fugue-ppl = "0.1.0"
+fugue-ppl = "0.2.0"
 rand = "0.8"
 ```
 


### PR DESCRIPTION
Cuts the 0.2.0 release: changelog section dated, version bumped in Cargo.toml/README/installation docs/citation, lockfile refreshed. `cargo publish --dry-run` verifies clean.

Merging this triggers the Publish workflow, which will ship `fugue-ppl 0.2.0` to crates.io (version gate passes since only 0.1.0 exists). **Merge and let Publish finish before fugue-evo's publish-setup PR** — evo's first release resolves `fugue-ppl 0.2` from the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEAKcbnLVP8iSXub2Pqor2