### PR TITLE
WASM playground: run real fugue in the browser (#40)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,40 @@ jobs:
       #   if: hashFiles('docs/**/*.md') != ''
       #   run: mdbook test docs
 
+  wasm:
+    name: WASM (fugue-wasm)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust (wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+          key: wasm
+
+      - name: Check WASM crate compiles for wasm32
+        run: cargo check -p fugue-wasm --target wasm32-unknown-unknown
+
+      - name: Native tests (DSL + interpreter)
+        run: cargo test -p fugue-wasm
+
+      - name: WASM boundary tests (Node)
+        run: wasm-pack test --node crates/fugue-wasm
+
+      - name: Build WASM package
+        run: wasm-pack build crates/fugue-wasm --target web --release
+
   msrv:
     name: MSRV (1.87.0)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
           # truncating the manifest at `[dev-dependencies]` here commits
           # nothing back and only scopes *this* check to what actually ships.
           sed -i '/^\[dev-dependencies\]/,$d' Cargo.toml
+          # Same reasoning for crates/fugue-wasm: it is an unpublished
+          # bindings crate (wasm-bindgen tooling has its own MSRV floor) and
+          # is never part of a downstream `cargo add fugue-ppl`. Drop it from
+          # the workspace so its dependency graph doesn't enter resolution.
+          sed -i 's#, "crates/fugue-wasm"##' Cargo.toml
           # The committed Cargo.lock may be a newer lock-file format than an
           # older cargo/rustc pair can parse; regenerating against the
           # trimmed manifest above is required (and sufficient -- verified

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,21 @@ on:
     paths: 
       - 'docs/**'
       - '.github/workflows/docs.yml'
+      # The book embeds a wasm-pack build of the real crate (playground +
+      # WASM-backed widgets), so library or bindings changes must redeploy it.
+      - 'src/**'
+      - 'crates/fugue-wasm/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
     branches: [ main ]
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+      - 'src/**'
+      - 'crates/fugue-wasm/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 jobs:
   # Job to test and validate documentation
@@ -21,6 +31,11 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Cache Cargo registry and target
         uses: actions/cache@v4
@@ -76,12 +91,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mdbook-
 
+      - name: Build WASM package (real fugue for the playground/widgets)
+        run: wasm-pack build crates/fugue-wasm --target web --release
+
       - name: Build documentation (validates structure)
         run: |
           cd docs
           # Build without linkcheck to avoid false positives with LaTeX math
           # Linkcheck has issues with math equations like \[ and \]
           mdbook build --skip-preprocessor linkcheck || mdbook build
+
+      - name: Embed WASM package next to the book
+        run: |
+          # Served at <site>/pkg/. The JS loader (docs/fugue-wasm-loader.js)
+          # dynamic-imports pkg/fugue_wasm.js and falls back to the mirrored
+          # JS math when the package is absent (e.g. local builds w/o wasm).
+          mkdir -p docs/book/pkg
+          cp crates/fugue-wasm/pkg/fugue_wasm.js \
+             crates/fugue-wasm/pkg/fugue_wasm_bg.wasm \
+             crates/fugue-wasm/pkg/package.json \
+             docs/book/pkg/
 
       - name: Validate documentation
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ For the initial 0.1.0 release notes, see `.github/CHANGELOG.md`.
 
 ## [Unreleased]
 
+### Added
+
+- **Incremental HMC session API**: `HmcSession` exposes the HMC kernel one
+  transition at a time (`step`, `step_recorded` with full leapfrog
+  trajectories and per-point Hamiltonians, `set_step_size`/`set_n_leapfrog`
+  live retuning). `hmc_chain` is now a thin wrapper over it; same-seed
+  equivalence is pinned by test. New public types: `HmcSession`,
+  `HmcStepInfo`, `LeapfrogPoint`.
+- **`crates/fugue-wasm`** (unpublished workspace member): wasm-bindgen
+  bindings that run the real crate in the browser — a `prob!`-subset DSL
+  interpreted into actual `Model` combinators, incremental multi-chain MH
+  (`WasmMh`), incremental HMC (`WasmHmc`), a bootstrap particle filter over
+  fugue's SMC primitives (`WasmParticleFilter`), one-shot adaptive tempered
+  SMC with log-evidence (`wasm_smc_run`), and log-joint grid evaluation for
+  posterior heatmaps (`log_joint_grid`). Powers the docs' Playground page
+  and the WASM-backed explorable widgets (mirrored-JS math remains only as
+  a fallback).
+
 ## [0.2.0] - 2026-07-13
 
 The entries below summarize a full-crate audit remediation (170 findings,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "copy_dir"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1054,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fugue-wasm"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "fugue-ppl",
+ "getrandom 0.2.16",
+ "js-sys",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,8 +1193,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2143,6 +2170,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
 ]
 
 [[package]]
@@ -4009,6 +4046,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
+[workspace]
+members = [".", "crates/fugue-wasm"]
+# docs/ holds a standalone helper package (fugue-docs-tests) with its own
+# manifest; keep it out of the workspace so its resolution stays independent.
+exclude = ["docs"]
+
 [package]
 name = "fugue-ppl"
 version = "0.2.0"

--- a/crates/fugue-wasm/Cargo.toml
+++ b/crates/fugue-wasm/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "fugue-wasm"
+version = "0.1.0"
+edition = "2021"
+authors = ["Alex Nodeland"]
+description = "WebAssembly bindings for fugue: run real fugue models and inference in the browser"
+license = "MIT"
+repository = "https://github.com/alexnodeland/fugue"
+# Distributed via `wasm-pack build` output (npm-shaped pkg/), not crates.io;
+# same arrangement as fugue-evo's crates/fugue-evo-wasm.
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+fugue = { package = "fugue-ppl", path = "../.." }
+
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+
+# Better panic diagnostics at the JS boundary (logs Rust file/line to the
+# console instead of an opaque `unreachable` trap).
+console_error_panic_hook = "0.1"
+
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# fugue pulls in rand 0.8 -> getrandom 0.2, which needs the "js" feature to
+# compile for wasm32-unknown-unknown (browser entropy via crypto.getRandomValues).
+# All samplers here are explicitly seeded; this only satisfies the linker.
+getrandom = { version = "0.2", features = ["js"] }
+rand = "0.8"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[package.metadata.wasm-pack.profile.release]
+# wasm-opt -Os keeps the shipped binary small without touching the root
+# crate's cargo release profile (which benches rely on).
+wasm-opt = ["-Os"]
+
+[package.metadata.wasm-pack.profile.release.wasm-bindgen]
+debug-js-glue = false
+demangle-name-section = true
+dwarf-debug-info = false

--- a/crates/fugue-wasm/src/dsl.rs
+++ b/crates/fugue-wasm/src/dsl.rs
@@ -1,0 +1,1323 @@
+//! A `prob!`-subset model language, interpreted into real fugue [`Model`]s.
+//!
+//! The playground (and the WASM-backed doc widgets) need to build models at
+//! runtime from user-editable source. This module parses a Rust-ish subset of
+//! the `prob!` macro language and folds it into fugue's actual combinators —
+//! `sample`, `observe`, `factor`, `pure`, `bind` — so everything downstream
+//! (handlers, traces, MH/HMC/SMC, diagnostics) is the real crate, not a
+//! mirror. Only model *construction* is interpreted.
+//!
+//! Supported grammar (statements end with `;`, the program ends with `pure`):
+//!
+//! ```text
+//! let p <- sample(addr!("p"), Beta(2.0, 2.0));
+//! let mu = 2.0 * p - 1.0;
+//! for i in 0..y.len() {
+//!     observe(addr!("y", i), Normal(mu, 0.8), y[i]);
+//! }
+//! factor(-0.5 * mu * mu);
+//! pure(p)
+//! ```
+//!
+//! Rust-style `Dist::new(...)` and a trailing `.unwrap()` are accepted and
+//! ignored sugar, so examples copied from the docs parse unchanged. Data
+//! arrays come from a JSON object (`{"y": [...], "x": [...]}`) or a bare
+//! JSON array (bound to `data`). Addresses are built with fugue's own
+//! `make_name`/`make_indexed`, so they are byte-identical to `addr!(..)` in
+//! compiled Rust.
+//!
+//! Total-evaluation policy: model-build code runs inside `bind` continuations
+//! where errors cannot propagate as `Result` (and wasm has no unwinding), so
+//! runtime soft errors (index out of bounds, invalid distribution parameters)
+//! degrade to `factor(-inf)` — "this parameter region is impossible" — and
+//! push a warning the host can surface. Static errors (syntax, unknown
+//! variables/distributions, wrong arities) are rejected at compile time.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::{Arc, Mutex};
+
+use fugue::core::address::{make_indexed, make_name};
+use fugue::*;
+
+// ---------------------------------------------------------------------------
+// Values
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub enum Value {
+    F64(f64),
+    Int(i64),
+    Bool(bool),
+    Arr(Arc<Vec<f64>>),
+}
+
+impl Value {
+    pub fn as_f64(&self) -> f64 {
+        match self {
+            Value::F64(x) => *x,
+            Value::Int(i) => *i as f64,
+            Value::Bool(b) => {
+                if *b {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
+            Value::Arr(_) => f64::NAN,
+        }
+    }
+
+    fn as_index(&self) -> Option<i64> {
+        match self {
+            Value::Int(i) => Some(*i),
+            Value::F64(x) if x.fract() == 0.0 && x.is_finite() => Some(*x as i64),
+            _ => None,
+        }
+    }
+
+    fn as_bool(&self) -> bool {
+        match self {
+            Value::Bool(b) => *b,
+            other => other.as_f64() != 0.0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AST
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub enum Expr {
+    Num(f64),
+    Int(i64),
+    Bool(bool),
+    Var(String),
+    Index(Box<Expr>, Box<Expr>),
+    Len(Box<Expr>),
+    Neg(Box<Expr>),
+    Bin(char, Box<Expr>, Box<Expr>),
+    Call(String, Vec<Expr>),
+}
+
+#[derive(Clone, Debug)]
+pub struct AddrSpec {
+    name: String,
+    index: Option<Expr>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DistSpec {
+    name: String,
+    args: Vec<Expr>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Stmt {
+    SampleLet {
+        name: String,
+        addr: AddrSpec,
+        dist: DistSpec,
+    },
+    LetExpr {
+        name: String,
+        expr: Expr,
+    },
+    Observe {
+        addr: AddrSpec,
+        dist: DistSpec,
+        value: Expr,
+    },
+    Factor(Expr),
+    For {
+        var: String,
+        lo: Expr,
+        hi: Expr,
+        body: Arc<Vec<Stmt>>,
+    },
+}
+
+#[derive(Debug)]
+pub struct Program {
+    stmts: Arc<Vec<Stmt>>,
+    ret: Arc<Expr>,
+}
+
+// ---------------------------------------------------------------------------
+// Lexer
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+enum Tok {
+    Ident(String),
+    Num(f64, bool), // value, had_dot_or_exp
+    Str(String),
+    Sym(&'static str),
+    Eof,
+}
+
+struct Lexer {
+    toks: Vec<(Tok, usize)>, // (token, byte offset for error reporting)
+    pos: usize,
+    src_line_starts: Vec<usize>,
+}
+
+const SYMS: &[&str] = &[
+    "<-", "::", "..", "(", ")", "{", "}", "[", "]", ",", ";", "+", "-", "*", "/", "=", ".", "!",
+];
+
+impl Lexer {
+    fn new(src: &str) -> Result<Lexer, String> {
+        let bytes = src.as_bytes();
+        let mut toks = Vec::new();
+        let mut i = 0;
+        let line_starts = std::iter::once(0)
+            .chain(src.match_indices('\n').map(|(p, _)| p + 1))
+            .collect();
+        'outer: while i < bytes.len() {
+            let c = bytes[i] as char;
+            if c.is_whitespace() {
+                i += 1;
+                continue;
+            }
+            if c == '/' && bytes.get(i + 1) == Some(&b'/') {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            if c == '"' {
+                let start = i + 1;
+                let mut j = start;
+                while j < bytes.len() && bytes[j] != b'"' {
+                    j += 1;
+                }
+                if j >= bytes.len() {
+                    return Err(format!("unterminated string at byte {i}"));
+                }
+                toks.push((Tok::Str(src[start..j].to_string()), i));
+                i = j + 1;
+                continue;
+            }
+            if c.is_ascii_digit() {
+                let start = i;
+                let mut seen_dot = false;
+                while i < bytes.len() {
+                    let d = bytes[i] as char;
+                    if d.is_ascii_digit() {
+                        i += 1;
+                    } else if d == '.'
+                        && !seen_dot
+                        && bytes.get(i + 1).is_some_and(|b| b.is_ascii_digit())
+                    {
+                        // Only consume '.' as a decimal point when a digit
+                        // follows: `0..n` must lex as Num(0) '..' ident.
+                        seen_dot = true;
+                        i += 1;
+                    } else if (d == 'e' || d == 'E')
+                        && bytes
+                            .get(i + 1)
+                            .is_some_and(|&b| b.is_ascii_digit() || b == b'-' || b == b'+')
+                    {
+                        seen_dot = true;
+                        i += 2;
+                        while i < bytes.len() && bytes[i].is_ascii_digit() {
+                            i += 1;
+                        }
+                        break;
+                    } else {
+                        break;
+                    }
+                }
+                let text = &src[start..i];
+                let v: f64 = text
+                    .parse()
+                    .map_err(|_| format!("bad number `{text}` at byte {start}"))?;
+                toks.push((Tok::Num(v, seen_dot), start));
+                continue;
+            }
+            if c.is_ascii_alphabetic() || c == '_' {
+                let start = i;
+                while i < bytes.len()
+                    && ((bytes[i] as char).is_ascii_alphanumeric() || bytes[i] == b'_')
+                {
+                    i += 1;
+                }
+                toks.push((Tok::Ident(src[start..i].to_string()), start));
+                continue;
+            }
+            for s in SYMS {
+                if src[i..].starts_with(s) {
+                    toks.push((Tok::Sym(s), i));
+                    i += s.len();
+                    continue 'outer;
+                }
+            }
+            return Err(format!("unexpected character `{c}` at byte {i}"));
+        }
+        toks.push((Tok::Eof, src.len()));
+        Ok(Lexer {
+            toks,
+            pos: 0,
+            src_line_starts: line_starts,
+        })
+    }
+
+    fn line_of(&self, byte: usize) -> usize {
+        match self.src_line_starts.binary_search(&byte) {
+            Ok(l) => l + 1,
+            Err(l) => l,
+        }
+    }
+
+    fn peek(&self) -> &Tok {
+        &self.toks[self.pos].0
+    }
+
+    fn peek2(&self) -> &Tok {
+        &self.toks[(self.pos + 1).min(self.toks.len() - 1)].0
+    }
+
+    fn next(&mut self) -> Tok {
+        let t = self.toks[self.pos].0.clone();
+        if self.pos < self.toks.len() - 1 {
+            self.pos += 1;
+        }
+        t
+    }
+
+    fn err(&self, what: &str) -> String {
+        let (tok, byte) = &self.toks[self.pos];
+        format!(
+            "line {}: expected {what}, found {}",
+            self.line_of(*byte),
+            match tok {
+                Tok::Ident(s) => format!("`{s}`"),
+                Tok::Num(v, _) => format!("`{v}`"),
+                Tok::Str(s) => format!("\"{s}\""),
+                Tok::Sym(s) => format!("`{s}`"),
+                Tok::Eof => "end of input".to_string(),
+            }
+        )
+    }
+
+    fn expect_sym(&mut self, s: &'static str) -> Result<(), String> {
+        if self.peek() == &Tok::Sym(s) {
+            self.next();
+            Ok(())
+        } else {
+            Err(self.err(&format!("`{s}`")))
+        }
+    }
+
+    fn expect_ident(&mut self) -> Result<String, String> {
+        match self.peek().clone() {
+            Tok::Ident(s) => {
+                self.next();
+                Ok(s)
+            }
+            _ => Err(self.err("an identifier")),
+        }
+    }
+
+    fn eat_kw(&mut self, kw: &str) -> bool {
+        if matches!(self.peek(), Tok::Ident(s) if s == kw) {
+            self.next();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+fn parse_program(src: &str) -> Result<Program, String> {
+    let mut lx = Lexer::new(src)?;
+    let mut stmts = Vec::new();
+    loop {
+        if lx.eat_kw("pure") {
+            lx.expect_sym("(")?;
+            let ret = parse_expr(&mut lx)?;
+            lx.expect_sym(")")?;
+            let _ = lx.expect_sym(";"); // optional trailing semicolon
+            if lx.peek() != &Tok::Eof {
+                return Err(lx.err("end of input after `pure(..)`"));
+            }
+            return Ok(Program {
+                stmts: Arc::new(stmts),
+                ret: Arc::new(ret),
+            });
+        }
+        if lx.peek() == &Tok::Eof {
+            return Err("model must end with `pure(<expr>)`".to_string());
+        }
+        stmts.push(parse_stmt(&mut lx)?);
+    }
+}
+
+fn parse_stmt(lx: &mut Lexer) -> Result<Stmt, String> {
+    if lx.eat_kw("let") {
+        let name = lx.expect_ident()?;
+        if lx.peek() == &Tok::Sym("<-") {
+            lx.next();
+            if !lx.eat_kw("sample") {
+                return Err(lx.err("`sample`"));
+            }
+            lx.expect_sym("(")?;
+            let addr = parse_addr(lx)?;
+            lx.expect_sym(",")?;
+            let dist = parse_dist(lx)?;
+            lx.expect_sym(")")?;
+            lx.expect_sym(";")?;
+            return Ok(Stmt::SampleLet { name, addr, dist });
+        }
+        lx.expect_sym("=")?;
+        let expr = parse_expr(lx)?;
+        lx.expect_sym(";")?;
+        return Ok(Stmt::LetExpr { name, expr });
+    }
+    if lx.eat_kw("observe") {
+        lx.expect_sym("(")?;
+        let addr = parse_addr(lx)?;
+        lx.expect_sym(",")?;
+        let dist = parse_dist(lx)?;
+        lx.expect_sym(",")?;
+        let value = parse_expr(lx)?;
+        lx.expect_sym(")")?;
+        lx.expect_sym(";")?;
+        return Ok(Stmt::Observe { addr, dist, value });
+    }
+    if lx.eat_kw("factor") {
+        lx.expect_sym("(")?;
+        let e = parse_expr(lx)?;
+        lx.expect_sym(")")?;
+        lx.expect_sym(";")?;
+        return Ok(Stmt::Factor(e));
+    }
+    if lx.eat_kw("for") {
+        let var = lx.expect_ident()?;
+        if !lx.eat_kw("in") {
+            return Err(lx.err("`in`"));
+        }
+        let lo = parse_expr(lx)?;
+        lx.expect_sym("..")?;
+        let hi = parse_expr(lx)?;
+        lx.expect_sym("{")?;
+        let mut body = Vec::new();
+        while lx.peek() != &Tok::Sym("}") {
+            if lx.peek() == &Tok::Eof {
+                return Err(lx.err("`}`"));
+            }
+            body.push(parse_stmt(lx)?);
+        }
+        lx.next(); // }
+        return Ok(Stmt::For {
+            var,
+            lo,
+            hi,
+            body: Arc::new(body),
+        });
+    }
+    Err(lx.err("a statement (`let`, `observe`, `factor`, `for`, or `pure`)"))
+}
+
+fn parse_addr(lx: &mut Lexer) -> Result<AddrSpec, String> {
+    if !lx.eat_kw("addr") {
+        return Err(lx.err("`addr!(..)`"));
+    }
+    lx.expect_sym("!")?;
+    lx.expect_sym("(")?;
+    let name = match lx.peek().clone() {
+        Tok::Str(s) => {
+            lx.next();
+            s
+        }
+        _ => return Err(lx.err("a string literal address name")),
+    };
+    let index = if lx.peek() == &Tok::Sym(",") {
+        lx.next();
+        Some(parse_expr(lx)?)
+    } else {
+        None
+    };
+    lx.expect_sym(")")?;
+    Ok(AddrSpec { name, index })
+}
+
+fn parse_dist(lx: &mut Lexer) -> Result<DistSpec, String> {
+    let name = lx.expect_ident()?;
+    if lx.peek() == &Tok::Sym("::") {
+        lx.next();
+        let m = lx.expect_ident()?;
+        if m != "new" {
+            return Err(format!("unknown distribution constructor `{name}::{m}`"));
+        }
+    }
+    lx.expect_sym("(")?;
+    let mut args = Vec::new();
+    if lx.peek() != &Tok::Sym(")") {
+        loop {
+            args.push(parse_expr(lx)?);
+            if lx.peek() == &Tok::Sym(",") {
+                lx.next();
+            } else {
+                break;
+            }
+        }
+    }
+    lx.expect_sym(")")?;
+    // Optional Rust-ism: `.unwrap()`
+    if lx.peek() == &Tok::Sym(".") && matches!(lx.peek2(), Tok::Ident(s) if s == "unwrap") {
+        lx.next();
+        lx.next();
+        lx.expect_sym("(")?;
+        lx.expect_sym(")")?;
+    }
+    dist_arity(&name)
+        .ok_or_else(|| format!("unknown distribution `{name}`"))
+        .and_then(|(lo, hi)| {
+            if args.len() < lo || args.len() > hi {
+                Err(format!(
+                    "`{name}` takes {} argument(s), got {}",
+                    if lo == hi {
+                        lo.to_string()
+                    } else {
+                        format!("{lo}..={hi}")
+                    },
+                    args.len()
+                ))
+            } else {
+                Ok(DistSpec { name, args })
+            }
+        })
+}
+
+fn parse_expr(lx: &mut Lexer) -> Result<Expr, String> {
+    parse_additive(lx)
+}
+
+fn parse_additive(lx: &mut Lexer) -> Result<Expr, String> {
+    let mut lhs = parse_multiplicative(lx)?;
+    loop {
+        let op = match lx.peek() {
+            Tok::Sym("+") => '+',
+            Tok::Sym("-") => '-',
+            _ => return Ok(lhs),
+        };
+        lx.next();
+        let rhs = parse_multiplicative(lx)?;
+        lhs = Expr::Bin(op, Box::new(lhs), Box::new(rhs));
+    }
+}
+
+fn parse_multiplicative(lx: &mut Lexer) -> Result<Expr, String> {
+    let mut lhs = parse_unary(lx)?;
+    loop {
+        let op = match lx.peek() {
+            Tok::Sym("*") => '*',
+            Tok::Sym("/") => '/',
+            _ => return Ok(lhs),
+        };
+        lx.next();
+        let rhs = parse_unary(lx)?;
+        lhs = Expr::Bin(op, Box::new(lhs), Box::new(rhs));
+    }
+}
+
+fn parse_unary(lx: &mut Lexer) -> Result<Expr, String> {
+    if lx.peek() == &Tok::Sym("-") {
+        lx.next();
+        return Ok(Expr::Neg(Box::new(parse_unary(lx)?)));
+    }
+    parse_postfix(lx)
+}
+
+fn parse_postfix(lx: &mut Lexer) -> Result<Expr, String> {
+    let mut e = parse_primary(lx)?;
+    loop {
+        match lx.peek() {
+            Tok::Sym("[") => {
+                lx.next();
+                let idx = parse_expr(lx)?;
+                lx.expect_sym("]")?;
+                e = Expr::Index(Box::new(e), Box::new(idx));
+            }
+            Tok::Sym(".") => {
+                // Only `.len()` — and NOT when the next token would start
+                // `.unwrap()` (handled by parse_dist) or a number.
+                if let Tok::Ident(m) = lx.peek2().clone() {
+                    if m == "len" {
+                        lx.next();
+                        lx.next();
+                        lx.expect_sym("(")?;
+                        lx.expect_sym(")")?;
+                        e = Expr::Len(Box::new(e));
+                        continue;
+                    }
+                }
+                return Ok(e);
+            }
+            _ => return Ok(e),
+        }
+    }
+}
+
+const MATH_FNS: &[(&str, usize)] = &[
+    ("exp", 1),
+    ("ln", 1),
+    ("log", 1),
+    ("sqrt", 1),
+    ("abs", 1),
+    ("floor", 1),
+    ("sin", 1),
+    ("cos", 1),
+    ("tanh", 1),
+    ("pow", 2),
+    ("min", 2),
+    ("max", 2),
+];
+
+fn parse_primary(lx: &mut Lexer) -> Result<Expr, String> {
+    match lx.peek().clone() {
+        Tok::Num(v, dotted) => {
+            lx.next();
+            if dotted {
+                Ok(Expr::Num(v))
+            } else {
+                Ok(Expr::Int(v as i64))
+            }
+        }
+        Tok::Sym("(") => {
+            lx.next();
+            let e = parse_expr(lx)?;
+            lx.expect_sym(")")?;
+            Ok(e)
+        }
+        Tok::Ident(name) => {
+            lx.next();
+            match name.as_str() {
+                "true" => return Ok(Expr::Bool(true)),
+                "false" => return Ok(Expr::Bool(false)),
+                _ => {}
+            }
+            if lx.peek() == &Tok::Sym("(") {
+                let arity = MATH_FNS
+                    .iter()
+                    .find(|(f, _)| *f == name)
+                    .map(|(_, a)| *a)
+                    .ok_or_else(|| format!("unknown function `{name}`"))?;
+                lx.next();
+                let mut args = Vec::new();
+                if lx.peek() != &Tok::Sym(")") {
+                    loop {
+                        args.push(parse_expr(lx)?);
+                        if lx.peek() == &Tok::Sym(",") {
+                            lx.next();
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                lx.expect_sym(")")?;
+                if args.len() != arity {
+                    return Err(format!("`{name}` takes {arity} argument(s)"));
+                }
+                Ok(Expr::Call(name, args))
+            } else {
+                Ok(Expr::Var(name))
+            }
+        }
+        _ => Err(lx.err("an expression")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Static validation (names, so runtime never sees an unknown identifier)
+// ---------------------------------------------------------------------------
+
+fn check_expr(e: &Expr, scope: &mut Vec<String>) -> Result<(), String> {
+    match e {
+        Expr::Var(n) => {
+            if scope.iter().any(|s| s == n) {
+                Ok(())
+            } else {
+                Err(format!("unknown variable `{n}`"))
+            }
+        }
+        Expr::Num(_) | Expr::Int(_) | Expr::Bool(_) => Ok(()),
+        Expr::Index(a, i) => check_expr(a, scope).and_then(|_| check_expr(i, scope)),
+        Expr::Len(a) | Expr::Neg(a) => check_expr(a, scope),
+        Expr::Bin(_, a, b) => check_expr(a, scope).and_then(|_| check_expr(b, scope)),
+        Expr::Call(_, args) => args.iter().try_for_each(|a| check_expr(a, scope)),
+    }
+}
+
+fn check_stmts(stmts: &[Stmt], scope: &mut Vec<String>) -> Result<(), String> {
+    for s in stmts {
+        match s {
+            Stmt::SampleLet { name, addr, dist } => {
+                if let Some(ix) = &addr.index {
+                    check_expr(ix, scope)?;
+                }
+                dist.args.iter().try_for_each(|a| check_expr(a, scope))?;
+                scope.push(name.clone());
+            }
+            Stmt::LetExpr { name, expr } => {
+                check_expr(expr, scope)?;
+                scope.push(name.clone());
+            }
+            Stmt::Observe { addr, dist, value } => {
+                if let Some(ix) = &addr.index {
+                    check_expr(ix, scope)?;
+                }
+                dist.args.iter().try_for_each(|a| check_expr(a, scope))?;
+                check_expr(value, scope)?;
+            }
+            Stmt::Factor(e) => check_expr(e, scope)?,
+            Stmt::For { var, lo, hi, body } => {
+                check_expr(lo, scope)?;
+                check_expr(hi, scope)?;
+                let depth = scope.len();
+                scope.push(var.clone());
+                check_stmts(body, scope)?;
+                scope.truncate(depth);
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct Env {
+    vars: HashMap<String, Value>,
+    warnings: Arc<Mutex<Vec<String>>>,
+}
+
+impl Env {
+    fn warn(&self, msg: String) {
+        if let Ok(mut w) = self.warnings.lock() {
+            if w.len() < 64 {
+                w.push(msg);
+            }
+        }
+    }
+}
+
+fn eval(e: &Expr, env: &Env) -> Value {
+    match e {
+        Expr::Num(v) => Value::F64(*v),
+        Expr::Int(i) => Value::Int(*i),
+        Expr::Bool(b) => Value::Bool(*b),
+        Expr::Var(n) => env.vars.get(n).cloned().unwrap_or_else(|| {
+            env.warn(format!("unknown variable `{n}` at runtime"));
+            Value::F64(f64::NAN)
+        }),
+        Expr::Index(a, ie) => {
+            let arr = eval(a, env);
+            let idx = eval(ie, env);
+            match (&arr, idx.as_index()) {
+                (Value::Arr(v), Some(i)) if i >= 0 && (i as usize) < v.len() => {
+                    Value::F64(v[i as usize])
+                }
+                (Value::Arr(v), Some(i)) => {
+                    env.warn(format!("index {i} out of bounds (len {})", v.len()));
+                    Value::F64(f64::NAN)
+                }
+                _ => {
+                    env.warn("indexing a non-array value".to_string());
+                    Value::F64(f64::NAN)
+                }
+            }
+        }
+        Expr::Len(a) => match eval(a, env) {
+            Value::Arr(v) => Value::Int(v.len() as i64),
+            _ => {
+                env.warn("`.len()` on a non-array value".to_string());
+                Value::Int(0)
+            }
+        },
+        Expr::Neg(a) => match eval(a, env) {
+            Value::Int(i) => Value::Int(-i),
+            other => Value::F64(-other.as_f64()),
+        },
+        Expr::Bin(op, a, b) => {
+            let va = eval(a, env);
+            let vb = eval(b, env);
+            if let (Value::Int(x), Value::Int(y), '+' | '-' | '*') = (&va, &vb, *op) {
+                return Value::Int(match op {
+                    '+' => x + y,
+                    '-' => x - y,
+                    _ => x * y,
+                });
+            }
+            let (x, y) = (va.as_f64(), vb.as_f64());
+            Value::F64(match op {
+                '+' => x + y,
+                '-' => x - y,
+                '*' => x * y,
+                _ => x / y,
+            })
+        }
+        Expr::Call(name, args) => {
+            let a: Vec<f64> = args.iter().map(|x| eval(x, env).as_f64()).collect();
+            Value::F64(match name.as_str() {
+                "exp" => a[0].exp(),
+                "ln" | "log" => a[0].ln(),
+                "sqrt" => a[0].sqrt(),
+                "abs" => a[0].abs(),
+                "floor" => a[0].floor(),
+                "sin" => a[0].sin(),
+                "cos" => a[0].cos(),
+                "tanh" => a[0].tanh(),
+                "pow" => a[0].powf(a[1]),
+                "min" => a[0].min(a[1]),
+                "max" => a[0].max(a[1]),
+                _ => f64::NAN,
+            })
+        }
+    }
+}
+
+fn eval_addr(a: &AddrSpec, env: &Env) -> Address {
+    match &a.index {
+        None => Address::new(make_name(&a.name)),
+        Some(ix) => {
+            let v = eval(ix, env);
+            match v.as_index() {
+                Some(i) => Address::new(make_indexed(&a.name, i)),
+                None => Address::new(make_indexed(&a.name, v.as_f64())),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Distributions
+// ---------------------------------------------------------------------------
+
+/// (min_args, max_args) per distribution; `Categorical` is variadic.
+fn dist_arity(name: &str) -> Option<(usize, usize)> {
+    Some(match name {
+        "Normal" | "Uniform" | "LogNormal" | "Beta" | "Gamma" | "InverseGamma" | "Cauchy"
+        | "Laplace" | "Weibull" | "Binomial" | "DiscreteUniform" => (2, 2),
+        "Exponential" | "Poisson" | "Bernoulli" | "ChiSquared" => (1, 1),
+        "StudentT" => (3, 3),
+        "Categorical" => (1, 64),
+        _ => return None,
+    })
+}
+
+enum BuiltDist {
+    F64(Box<dyn Distribution<f64>>),
+    Bool(Box<dyn Distribution<bool>>),
+    U64(Box<dyn Distribution<u64>>),
+    Usize(Box<dyn Distribution<usize>>),
+    I64(Box<dyn Distribution<i64>>),
+}
+
+fn build_dist(spec: &DistSpec, env: &Env) -> Result<BuiltDist, String> {
+    let a: Vec<f64> = spec.args.iter().map(|x| eval(x, env).as_f64()).collect();
+    let d = |r: Result<BuiltDist, FugueError>| r.map_err(|e| e.to_string());
+    match spec.name.as_str() {
+        "Normal" => d(Normal::new(a[0], a[1]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "Uniform" => d(Uniform::new(a[0], a[1]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "LogNormal" => d(LogNormal::new(a[0], a[1]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "Beta" => d(Beta::new(a[0], a[1]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "Gamma" => d(Gamma::new(a[0], a[1]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "InverseGamma" => d(InverseGamma::new(a[0], a[1]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "Cauchy" => d(Cauchy::new(a[0], a[1]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "Laplace" => d(Laplace::new(a[0], a[1]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "Weibull" => d(Weibull::new(a[0], a[1]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "Exponential" => d(Exponential::new(a[0]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "ChiSquared" => d(ChiSquared::new(a[0]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "StudentT" => d(StudentT::new(a[0], a[1], a[2]).map(|x| BuiltDist::F64(Box::new(x)))),
+        "Bernoulli" => d(Bernoulli::new(a[0]).map(|x| BuiltDist::Bool(Box::new(x)))),
+        "Binomial" => {
+            if a[0] < 0.0 || a[0].fract() != 0.0 {
+                return Err(format!("Binomial n must be a non-negative integer, got {}", a[0]));
+            }
+            d(Binomial::new(a[0] as u64, a[1]).map(|x| BuiltDist::U64(Box::new(x))))
+        }
+        "Poisson" => d(Poisson::new(a[0]).map(|x| BuiltDist::U64(Box::new(x)))),
+        "Categorical" => d(Categorical::new(a.clone()).map(|x| BuiltDist::Usize(Box::new(x)))),
+        "DiscreteUniform" => d(DiscreteUniform::new(a[0] as i64, a[1] as i64)
+            .map(|x| BuiltDist::I64(Box::new(x)))),
+        other => Err(format!("unknown distribution `{other}`")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Interpretation: AST -> Model
+// ---------------------------------------------------------------------------
+
+/// Explicit continuation so `for` bodies and trailing statements compose
+/// without recursion at build time (the `run` trampoline drives everything).
+enum Cont {
+    Stmts(Arc<Vec<Stmt>>, usize, Box<Cont>),
+    Loop {
+        var: String,
+        i: i64,
+        hi: i64,
+        body: Arc<Vec<Stmt>>,
+        after: Box<Cont>,
+    },
+    Ret(Arc<Expr>),
+}
+
+fn interp(env: Env, cont: Cont) -> Model<f64> {
+    match cont {
+        Cont::Ret(ret) => pure(eval(&ret, &env).as_f64()),
+        Cont::Loop {
+            var,
+            i,
+            hi,
+            body,
+            after,
+        } => {
+            if i >= hi {
+                interp(env, *after)
+            } else {
+                let mut env2 = env;
+                env2.vars.insert(var.clone(), Value::Int(i));
+                interp(
+                    env2,
+                    Cont::Stmts(
+                        body.clone(),
+                        0,
+                        Box::new(Cont::Loop {
+                            var,
+                            i: i + 1,
+                            hi,
+                            body,
+                            after,
+                        }),
+                    ),
+                )
+            }
+        }
+        Cont::Stmts(stmts, idx, after) => {
+            if idx >= stmts.len() {
+                return interp(env, *after);
+            }
+            let next = |after: Box<Cont>| Cont::Stmts(stmts.clone(), idx + 1, after);
+            match stmts[idx].clone() {
+                Stmt::LetExpr { name, expr } => {
+                    let mut env2 = env;
+                    let v = eval(&expr, &env2);
+                    env2.vars.insert(name, v);
+                    interp(env2, next(after))
+                }
+                Stmt::Factor(e) => {
+                    let lw = eval(&e, &env).as_f64();
+                    let k = next(after);
+                    factor(if lw.is_nan() { f64::NEG_INFINITY } else { lw })
+                        .bind(move |_| interp(env, k))
+                }
+                Stmt::SampleLet { name, addr, dist } => {
+                    let a = eval_addr(&addr, &env);
+                    match build_dist(&dist, &env) {
+                        Ok(built) => {
+                            let k = next(after);
+                            match built {
+                                BuiltDist::F64(d) => sample(a, DynDist(d)).bind(move |v| {
+                                    let mut env2 = env;
+                                    env2.vars.insert(name, Value::F64(v));
+                                    interp(env2, k)
+                                }),
+                                BuiltDist::Bool(d) => sample(a, DynDist(d)).bind(move |v| {
+                                    let mut env2 = env;
+                                    env2.vars.insert(name, Value::Bool(v));
+                                    interp(env2, k)
+                                }),
+                                BuiltDist::U64(d) => sample(a, DynDist(d)).bind(move |v| {
+                                    let mut env2 = env;
+                                    env2.vars.insert(name, Value::Int(v as i64));
+                                    interp(env2, k)
+                                }),
+                                BuiltDist::Usize(d) => sample(a, DynDist(d)).bind(move |v| {
+                                    let mut env2 = env;
+                                    env2.vars.insert(name, Value::Int(v as i64));
+                                    interp(env2, k)
+                                }),
+                                BuiltDist::I64(d) => sample(a, DynDist(d)).bind(move |v| {
+                                    let mut env2 = env;
+                                    env2.vars.insert(name, Value::Int(v));
+                                    interp(env2, k)
+                                }),
+                            }
+                        }
+                        Err(msg) => {
+                            // Invalid parameters at this point of parameter
+                            // space: impossible region. Sample a placeholder
+                            // so downstream code still has a value, and kill
+                            // the weight.
+                            env.warn(format!("sample `{name}`: {msg}"));
+                            let k = next(after);
+                            let a2 = a.clone();
+                            sample(a2, Normal::new(0.0, 1.0).unwrap())
+                                .bind(move |v| {
+                                    factor(f64::NEG_INFINITY).bind(move |_| {
+                                        let mut env2 = env;
+                                        env2.vars.insert(name, Value::F64(v));
+                                        interp(env2, k)
+                                    })
+                                })
+                        }
+                    }
+                }
+                Stmt::Observe { addr, dist, value } => {
+                    let a = eval_addr(&addr, &env);
+                    let v = eval(&value, &env);
+                    match build_dist(&dist, &env) {
+                        Ok(built) => {
+                            let k = next(after);
+                            let m: Model<()> = match built {
+                                BuiltDist::F64(d) => observe(a, DynDist(d), v.as_f64()),
+                                BuiltDist::Bool(d) => observe(a, DynDist(d), v.as_bool()),
+                                BuiltDist::U64(d) => {
+                                    observe(a, DynDist(d), v.as_index().unwrap_or(0).max(0) as u64)
+                                }
+                                BuiltDist::Usize(d) => observe(
+                                    a,
+                                    DynDist(d),
+                                    v.as_index().unwrap_or(0).max(0) as usize,
+                                ),
+                                BuiltDist::I64(d) => observe(a, DynDist(d), v.as_index().unwrap_or(0)),
+                            };
+                            m.bind(move |_| interp(env, k))
+                        }
+                        Err(msg) => {
+                            env.warn(format!("observe at `{}`: {msg}", a));
+                            let k = next(after);
+                            factor(f64::NEG_INFINITY).bind(move |_| interp(env, k))
+                        }
+                    }
+                }
+                Stmt::For { var, lo, hi, body } => {
+                    let lo_v = eval(&lo, &env).as_index().unwrap_or_else(|| {
+                        env.warn("`for` lower bound is not an integer".to_string());
+                        0
+                    });
+                    let hi_v = eval(&hi, &env).as_index().unwrap_or_else(|| {
+                        env.warn("`for` upper bound is not an integer".to_string());
+                        0
+                    });
+                    interp(
+                        env,
+                        Cont::Loop {
+                            var,
+                            i: lo_v,
+                            hi: hi_v,
+                            body,
+                            after: Box::new(next(after)),
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+/// Adapter: fugue's `sample`/`observe` take `impl Distribution<T> + 'static`
+/// by value, but the DSL builds `Box<dyn Distribution<T>>` at runtime.
+struct DynDist<T>(Box<dyn Distribution<T>>);
+
+impl<T: Clone + 'static> Distribution<T> for DynDist<T> {
+    fn sample(&self, rng: &mut dyn rand::RngCore) -> T {
+        self.0.sample(rng)
+    }
+    fn log_prob(&self, x: &T) -> f64 {
+        self.0.log_prob(x)
+    }
+    fn clone_box(&self) -> Box<dyn Distribution<T>> {
+        self.0.clone_box()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public compiled-model handle
+// ---------------------------------------------------------------------------
+
+/// A parsed, validated model plus its data environment. `build()` constructs
+/// a fresh single-use [`Model`], so `|| compiled.build()` is the `model_fn`
+/// every fugue inference driver wants.
+pub struct CompiledModel {
+    prog: Arc<Program>,
+    base_env: Env,
+}
+
+impl CompiledModel {
+    /// Parse `source` and bind data arrays from `data_json` — a JSON object
+    /// of number arrays (`{"y": [...], ...}`), a bare array (bound to
+    /// `data`), or empty/`null` for no data. Booleans are coerced to 0/1.
+    pub fn compile(source: &str, data_json: &str) -> Result<CompiledModel, String> {
+        let prog = parse_program(source)?;
+        let mut vars = HashMap::new();
+        let trimmed = data_json.trim();
+        if !trimmed.is_empty() && trimmed != "null" {
+            let parsed: serde_json::Value =
+                serde_json::from_str(trimmed).map_err(|e| format!("data is not valid JSON: {e}"))?;
+            let to_arr = |v: &serde_json::Value| -> Result<Vec<f64>, String> {
+                v.as_array()
+                    .ok_or_else(|| "data arrays must be JSON arrays".to_string())?
+                    .iter()
+                    .map(|x| {
+                        x.as_f64()
+                            .or(x.as_bool().map(|b| if b { 1.0 } else { 0.0 }))
+                            .ok_or_else(|| "data arrays must hold numbers or booleans".to_string())
+                    })
+                    .collect()
+            };
+            match &parsed {
+                serde_json::Value::Array(_) => {
+                    vars.insert("data".to_string(), Value::Arr(Arc::new(to_arr(&parsed)?)));
+                }
+                serde_json::Value::Object(map) => {
+                    for (k, v) in map {
+                        vars.insert(k.clone(), Value::Arr(Arc::new(to_arr(v)?)));
+                    }
+                }
+                _ => return Err("data must be a JSON array or object of arrays".to_string()),
+            }
+        }
+        let mut scope: Vec<String> = vars.keys().cloned().collect();
+        check_stmts(&prog.stmts, &mut scope)?;
+        check_expr(&prog.ret, &mut scope)?;
+        Ok(CompiledModel {
+            prog: Arc::new(prog),
+            base_env: Env {
+                vars,
+                warnings: Arc::new(Mutex::new(Vec::new())),
+            },
+        })
+    }
+
+    /// Build a fresh single-use model.
+    pub fn build(&self) -> Model<f64> {
+        let env = self.base_env.clone();
+        interp(
+            env,
+            Cont::Stmts(
+                self.prog.stmts.clone(),
+                0,
+                Box::new(Cont::Ret(self.prog.ret.clone())),
+            ),
+        )
+    }
+
+    /// Drain accumulated runtime warnings (soft errors mapped to `-inf`).
+    pub fn take_warnings(&self) -> Vec<String> {
+        self.base_env
+            .warnings
+            .lock()
+            .map(|mut w| std::mem::take(&mut *w))
+            .unwrap_or_default()
+    }
+
+    /// Human-readable summary of the data environment (for error messages).
+    pub fn data_summary(&self) -> String {
+        let mut s = String::new();
+        for (k, v) in &self.base_env.vars {
+            if let Value::Arr(a) = v {
+                let _ = write!(s, "{k}[{}] ", a.len());
+            }
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fugue::inference::mh::adaptive_mcmc_chain;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    const COIN: &str = r#"
+        let p <- sample(addr!("p"), Beta(2.0, 2.0));
+        for i in 0..data.len() {
+            observe(addr!("flip", i), Bernoulli(p), data[i]);
+        }
+        pure(p)
+    "#;
+
+    #[test]
+    fn coin_model_matches_native_addresses_and_posterior() {
+        let data = "[1,0,1,1,0,1,1,0,1,1]"; // 7 heads, 3 tails
+        let cm = CompiledModel::compile(COIN, data).unwrap();
+
+        // Address parity with the addr! macro.
+        let mut rng = StdRng::seed_from_u64(11);
+        let (_, t) = fugue::runtime::handler::run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            cm.build(),
+        );
+        assert!(t.get_f64(&addr!("p")).is_some());
+        // Observations are scored, not recorded as choices.
+        assert_eq!(t.choices.len(), 1);
+        assert!(t.log_likelihood.is_finite() && t.log_likelihood < 0.0);
+
+        // Real inference on the interpreted model recovers the conjugate
+        // posterior mean Beta(2+7, 2+3) => 9/14.
+        let mut rng = StdRng::seed_from_u64(11);
+        let samples = adaptive_mcmc_chain(&mut rng, || cm.build(), 4000, 1000);
+        let ps: Vec<f64> = samples
+            .iter()
+            .filter_map(|(_, t)| t.get_f64(&addr!("p")))
+            .collect();
+        let mean = ps.iter().sum::<f64>() / ps.len() as f64;
+        assert!((mean - 9.0 / 14.0).abs() < 0.03, "mean {mean}");
+    }
+
+    #[test]
+    fn regression_model_with_named_arrays() {
+        let src = r#"
+            let a <- sample(addr!("a"), Normal(0.0, 2.5));
+            let b <- sample(addr!("b"), Normal(0.0, 2.5));
+            for i in 0..x.len() {
+                observe(addr!("y", i), Normal(a * x[i] + b, 0.8), y[i]);
+            }
+            pure(a)
+        "#;
+        let data = r#"{"x": [-2, -1, 0, 1, 2], "y": [-2.1, -1.3, -0.4, 0.5, 1.2]}"#;
+        let cm = CompiledModel::compile(src, data).unwrap();
+        let mut rng = StdRng::seed_from_u64(3);
+        let samples = adaptive_mcmc_chain(&mut rng, || cm.build(), 2000, 500);
+        let a_mean: f64 = samples
+            .iter()
+            .filter_map(|(_, t)| t.get_f64(&addr!("a")))
+            .sum::<f64>()
+            / samples.len() as f64;
+        // True slope ~0.85 for this tiny dataset; just check sanity.
+        assert!(a_mean > 0.4 && a_mean < 1.4, "a_mean {a_mean}");
+    }
+
+    #[test]
+    fn indexed_sample_addresses_match_addr_macro() {
+        let src = r#"
+            for i in 0..3 {
+                let z <- sample(addr!("z", i), Normal(0.0, 1.0));
+            }
+            pure(0.0)
+        "#;
+        let cm = CompiledModel::compile(src, "").unwrap();
+        let mut rng = StdRng::seed_from_u64(1);
+        let (_, t) = fugue::runtime::handler::run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            cm.build(),
+        );
+        assert!(t.choices.contains_key(&addr!("z", 0)));
+        assert!(t.choices.contains_key(&addr!("z", 2)));
+        assert_eq!(t.choices.len(), 3);
+    }
+
+    #[test]
+    fn rust_ish_sugar_parses() {
+        let src = r#"
+            let mu <- sample(addr!("mu"), Normal::new(0.0, 1.0).unwrap());
+            observe(addr!("y"), Normal::new(mu, 1.0).unwrap(), 0.5);
+            pure(mu)
+        "#;
+        assert!(CompiledModel::compile(src, "").is_ok());
+    }
+
+    #[test]
+    fn static_errors_are_caught() {
+        assert!(CompiledModel::compile("pure(nope)", "").is_err());
+        assert!(CompiledModel::compile("let x <- sample(addr!(\"x\"), Nope(1.0)); pure(x)", "")
+            .is_err());
+        assert!(CompiledModel::compile(
+            "let x <- sample(addr!(\"x\"), Normal(1.0)); pure(x)",
+            ""
+        )
+        .is_err());
+        assert!(CompiledModel::compile("let x = 1.0;", "").is_err()); // no pure
+        let err = match CompiledModel::compile(
+            "let x <- sample(addr!(\"x\") Normal(0,1)); pure(x)",
+            "",
+        ) {
+            Err(e) => e,
+            Ok(_) => panic!("missing comma must not parse"),
+        };
+        assert!(err.contains("line"), "error should carry a line: {err}");
+    }
+
+    #[test]
+    fn invalid_params_kill_weight_not_process() {
+        // sigma = -1 is impossible: the model must still run (prior draw)
+        // with -inf total weight, not crash.
+        let src = r#"
+            let mu <- sample(addr!("mu"), Normal(0.0, -1.0));
+            pure(mu)
+        "#;
+        let cm = CompiledModel::compile(src, "").unwrap();
+        let mut rng = StdRng::seed_from_u64(0);
+        let (_, t) = fugue::runtime::handler::run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            cm.build(),
+        );
+        assert_eq!(t.total_log_weight(), f64::NEG_INFINITY);
+        assert!(!cm.take_warnings().is_empty());
+    }
+
+    #[test]
+    fn factor_and_math_functions() {
+        let src = r#"
+            let x <- sample(addr!("x"), Normal(0.0, 1.0));
+            factor(-0.5 * pow(x - 1.0, 2.0));
+            pure(exp(x) / (1.0 + exp(x)))
+        "#;
+        let cm = CompiledModel::compile(src, "").unwrap();
+        let mut rng = StdRng::seed_from_u64(5);
+        let (r, t) = fugue::runtime::handler::run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            cm.build(),
+        );
+        assert!(r > 0.0 && r < 1.0);
+        assert!(t.log_factors < 0.0);
+    }
+
+    #[test]
+    fn discrete_sites_sample_and_observe() {
+        let src = r#"
+            let k <- sample(addr!("k"), Poisson(4.0));
+            let z <- sample(addr!("z"), Categorical(0.3, 0.7));
+            observe(addr!("n"), Binomial(10, 0.5), 7);
+            observe(addr!("flag"), Bernoulli(0.5), true);
+            pure(k + z)
+        "#;
+        let cm = CompiledModel::compile(src, "").unwrap();
+        let mut rng = StdRng::seed_from_u64(2);
+        let (_, t) = fugue::runtime::handler::run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            cm.build(),
+        );
+        assert!(t.get_u64(&addr!("k")).is_some());
+        assert!(t.get_usize(&addr!("z")).is_some());
+        assert!(t.total_log_weight().is_finite());
+        assert!(cm.take_warnings().is_empty());
+    }
+}

--- a/crates/fugue-wasm/src/dsl.rs
+++ b/crates/fugue-wasm/src/dsl.rs
@@ -842,14 +842,18 @@ fn build_dist(spec: &DistSpec, env: &Env) -> Result<BuiltDist, String> {
         "Bernoulli" => d(Bernoulli::new(a[0]).map(|x| BuiltDist::Bool(Box::new(x)))),
         "Binomial" => {
             if a[0] < 0.0 || a[0].fract() != 0.0 {
-                return Err(format!("Binomial n must be a non-negative integer, got {}", a[0]));
+                return Err(format!(
+                    "Binomial n must be a non-negative integer, got {}",
+                    a[0]
+                ));
             }
             d(Binomial::new(a[0] as u64, a[1]).map(|x| BuiltDist::U64(Box::new(x))))
         }
         "Poisson" => d(Poisson::new(a[0]).map(|x| BuiltDist::U64(Box::new(x)))),
         "Categorical" => d(Categorical::new(a.clone()).map(|x| BuiltDist::Usize(Box::new(x)))),
-        "DiscreteUniform" => d(DiscreteUniform::new(a[0] as i64, a[1] as i64)
-            .map(|x| BuiltDist::I64(Box::new(x)))),
+        "DiscreteUniform" => {
+            d(DiscreteUniform::new(a[0] as i64, a[1] as i64).map(|x| BuiltDist::I64(Box::new(x))))
+        }
         other => Err(format!("unknown distribution `{other}`")),
     }
 }
@@ -962,14 +966,13 @@ fn interp(env: Env, cont: Cont) -> Model<f64> {
                             env.warn(format!("sample `{name}`: {msg}"));
                             let k = next(after);
                             let a2 = a.clone();
-                            sample(a2, Normal::new(0.0, 1.0).unwrap())
-                                .bind(move |v| {
-                                    factor(f64::NEG_INFINITY).bind(move |_| {
-                                        let mut env2 = env;
-                                        env2.vars.insert(name, Value::F64(v));
-                                        interp(env2, k)
-                                    })
+                            sample(a2, Normal::new(0.0, 1.0).unwrap()).bind(move |v| {
+                                factor(f64::NEG_INFINITY).bind(move |_| {
+                                    let mut env2 = env;
+                                    env2.vars.insert(name, Value::F64(v));
+                                    interp(env2, k)
                                 })
+                            })
                         }
                     }
                 }
@@ -990,7 +993,9 @@ fn interp(env: Env, cont: Cont) -> Model<f64> {
                                     DynDist(d),
                                     v.as_index().unwrap_or(0).max(0) as usize,
                                 ),
-                                BuiltDist::I64(d) => observe(a, DynDist(d), v.as_index().unwrap_or(0)),
+                                BuiltDist::I64(d) => {
+                                    observe(a, DynDist(d), v.as_index().unwrap_or(0))
+                                }
                             };
                             m.bind(move |_| interp(env, k))
                         }
@@ -1063,8 +1068,8 @@ impl CompiledModel {
         let mut vars = HashMap::new();
         let trimmed = data_json.trim();
         if !trimmed.is_empty() && trimmed != "null" {
-            let parsed: serde_json::Value =
-                serde_json::from_str(trimmed).map_err(|e| format!("data is not valid JSON: {e}"))?;
+            let parsed: serde_json::Value = serde_json::from_str(trimmed)
+                .map_err(|e| format!("data is not valid JSON: {e}"))?;
             let to_arr = |v: &serde_json::Value| -> Result<Vec<f64>, String> {
                 v.as_array()
                     .ok_or_else(|| "data arrays must be JSON arrays".to_string())?
@@ -1238,13 +1243,14 @@ mod tests {
     #[test]
     fn static_errors_are_caught() {
         assert!(CompiledModel::compile("pure(nope)", "").is_err());
-        assert!(CompiledModel::compile("let x <- sample(addr!(\"x\"), Nope(1.0)); pure(x)", "")
-            .is_err());
-        assert!(CompiledModel::compile(
-            "let x <- sample(addr!(\"x\"), Normal(1.0)); pure(x)",
-            ""
-        )
-        .is_err());
+        assert!(
+            CompiledModel::compile("let x <- sample(addr!(\"x\"), Nope(1.0)); pure(x)", "")
+                .is_err()
+        );
+        assert!(
+            CompiledModel::compile("let x <- sample(addr!(\"x\"), Normal(1.0)); pure(x)", "")
+                .is_err()
+        );
         assert!(CompiledModel::compile("let x = 1.0;", "").is_err()); // no pure
         let err = match CompiledModel::compile(
             "let x <- sample(addr!(\"x\") Normal(0,1)); pure(x)",

--- a/crates/fugue-wasm/src/grid.rs
+++ b/crates/fugue-wasm/src/grid.rs
@@ -1,0 +1,69 @@
+//! Log-joint evaluation over a 2-D parameter grid, for posterior heatmaps.
+//!
+//! The widgets draw their posterior-density backgrounds from this: every
+//! grid point is scored by running the real model under `ScoreGivenTrace`
+//! with the two chosen sites pinned — the same evaluation MH/HMC use for
+//! their accept ratios, so the heat is exactly the surface the samplers walk.
+
+use fugue::runtime::interpreters::PriorHandler;
+use fugue::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use wasm_bindgen::prelude::*;
+
+use crate::dsl::CompiledModel;
+
+/// Evaluate the unnormalized log-joint on the grid `a_values x b_values`
+/// for the two `f64` sites `site_a`/`site_b`. Any other latent sites are
+/// held at a fixed prior draw (seeded, so the surface is reproducible).
+/// Returns row-major values: `out[j * a_values.len() + i]` scores
+/// `(a_values[i], b_values[j])`.
+#[wasm_bindgen]
+pub fn log_joint_grid(
+    source: &str,
+    data_json: &str,
+    site_a: &str,
+    site_b: &str,
+    a_values: &[f64],
+    b_values: &[f64],
+    seed: u64,
+) -> Result<Vec<f64>, JsValue> {
+    let model = CompiledModel::compile(source, data_json).map_err(|e| JsValue::from_str(&e))?;
+    let mut rng = StdRng::seed_from_u64(seed);
+    let (_, base) = fugue::runtime::handler::run(
+        PriorHandler {
+            rng: &mut rng,
+            trace: Trace::default(),
+        },
+        model.build(),
+    );
+    let addr_a = Address::new(site_a.to_string());
+    let addr_b = Address::new(site_b.to_string());
+    if base.get_f64(&addr_a).is_none() || base.get_f64(&addr_b).is_none() {
+        return Err(JsValue::from_str(&format!(
+            "sites `{site_a}`/`{site_b}` must be f64 sample sites of the model"
+        )));
+    }
+
+    let mut out = Vec::with_capacity(a_values.len() * b_values.len());
+    for &b in b_values {
+        for &a in a_values {
+            let mut t = base.clone();
+            if let Some(c) = t.choices.get_mut(&addr_a) {
+                c.value = ChoiceValue::F64(a);
+            }
+            if let Some(c) = t.choices.get_mut(&addr_b) {
+                c.value = ChoiceValue::F64(b);
+            }
+            let (_, scored) = fugue::runtime::handler::run(
+                ScoreGivenTrace {
+                    base: t,
+                    trace: Trace::default(),
+                },
+                model.build(),
+            );
+            out.push(scored.total_log_weight());
+        }
+    }
+    Ok(out)
+}

--- a/crates/fugue-wasm/src/hmc.rs
+++ b/crates/fugue-wasm/src/hmc.rs
@@ -1,0 +1,159 @@
+//! Incremental HMC for the browser, over fugue's `HmcSession`.
+//!
+//! One `step_recorded()` per widget transition returns the full leapfrog
+//! trajectory (positions + Hamiltonians) so the renderer can animate the
+//! "rolling" proposal exactly as fugue computed it.
+
+use fugue::inference::hmc::{HMCConfig, HmcSession};
+use fugue::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+use crate::dsl::CompiledModel;
+
+#[derive(Serialize)]
+struct StepOut {
+    accepted: bool,
+    divergent: bool,
+    accept_prob: f64,
+    step_size: f64,
+    /// Row-major [n_points][dim] leapfrog positions (start included).
+    trajectory_q: Vec<Vec<f64>>,
+    /// Hamiltonian at each trajectory point.
+    trajectory_h: Vec<f64>,
+    /// Position after the transition.
+    position: Vec<f64>,
+    log_weight: f64,
+}
+
+/// A single incremental HMC chain over one compiled model.
+#[wasm_bindgen]
+pub struct WasmHmc {
+    model: CompiledModel,
+    session: HmcSession<f64>,
+    rng: StdRng,
+    history: Vec<Trace>,
+}
+
+#[wasm_bindgen]
+impl WasmHmc {
+    /// Compile `source` against `data_json` and initialize a chain.
+    /// `step_size <= 0` lets fugue's reasonable-epsilon heuristic pick one;
+    /// `n_warmup > 0` enables dual-averaging warmup for that many steps.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        source: &str,
+        data_json: &str,
+        seed: u64,
+        n_warmup: usize,
+        n_leapfrog: usize,
+        step_size: f64,
+    ) -> Result<WasmHmc, JsValue> {
+        let model = CompiledModel::compile(source, data_json).map_err(|e| JsValue::from_str(&e))?;
+        let config = HMCConfig {
+            n_leapfrog: n_leapfrog.clamp(1, 200),
+            init_step_size: if step_size > 0.0 {
+                Some(step_size)
+            } else {
+                None
+            },
+            ..HMCConfig::default()
+        };
+        let mut rng = StdRng::seed_from_u64(seed);
+        let session = HmcSession::new(&mut rng, &(|| model.build()), n_warmup, config);
+        Ok(WasmHmc {
+            model,
+            session,
+            rng,
+            history: Vec::new(),
+        })
+    }
+
+    /// The continuous site addresses the chain moves (coordinate order of
+    /// every position/trajectory array).
+    pub fn site_names(&self) -> Vec<String> {
+        self.session
+            .sites()
+            .iter()
+            .map(|a| a.to_string())
+            .collect()
+    }
+
+    /// One transition WITH trajectory recording; returns a JSON string of
+    /// `{accepted, divergent, accept_prob, step_size, trajectory_q,
+    /// trajectory_h, position, log_weight}`.
+    pub fn step_recorded(&mut self) -> String {
+        let model = &self.model;
+        let info = self
+            .session
+            .step_recorded(&mut self.rng, &(|| model.build()));
+        self.push_history();
+        let out = StepOut {
+            accepted: info.accepted,
+            divergent: info.divergent,
+            accept_prob: info.accept_prob,
+            step_size: info.step_size,
+            trajectory_q: info.trajectory.iter().map(|p| p.q.clone()).collect(),
+            trajectory_h: info.trajectory.iter().map(|p| p.h).collect(),
+            position: self.session.position().to_vec(),
+            log_weight: self.session.trace().total_log_weight(),
+        };
+        serde_json::to_string(&out).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// Advance `n` transitions without recording (warmup, fast-forward).
+    /// Returns how many were accepted.
+    pub fn step(&mut self, n: usize) -> usize {
+        let mut accepted = 0;
+        for _ in 0..n {
+            let model = &self.model;
+            let info = self.session.step(&mut self.rng, &(|| model.build()));
+            if info.accepted {
+                accepted += 1;
+            }
+            self.push_history();
+        }
+        accepted
+    }
+
+    /// Whether the next step still adapts the step size.
+    pub fn is_warming_up(&self) -> bool {
+        self.session.is_warming_up()
+    }
+
+    /// The step size the next transition will use.
+    pub fn step_size(&self) -> f64 {
+        self.session.step_size()
+    }
+
+    /// History of one coordinate (by site name) across recorded transitions.
+    pub fn values(&self, site: &str) -> Vec<f64> {
+        let addr = Address::new(site.to_string());
+        self.history
+            .iter()
+            .filter_map(|t| t.get_f64(&addr))
+            .collect()
+    }
+
+    /// Single-chain ESS of a coordinate over the recorded history, via
+    /// fugue's `effective_sample_size_mcmc`.
+    pub fn ess(&self, site: &str) -> f64 {
+        effective_sample_size_mcmc(&self.values(site))
+    }
+
+    /// Drain runtime model warnings.
+    pub fn warnings(&self) -> Vec<String> {
+        self.model.take_warnings()
+    }
+}
+
+impl WasmHmc {
+    fn push_history(&mut self) {
+        if self.history.len() >= 20_000 {
+            self.history.drain(0..10_000);
+        }
+        self.history.push(self.session.trace().clone());
+    }
+}

--- a/crates/fugue-wasm/src/hmc.rs
+++ b/crates/fugue-wasm/src/hmc.rs
@@ -74,11 +74,7 @@ impl WasmHmc {
     /// The continuous site addresses the chain moves (coordinate order of
     /// every position/trajectory array).
     pub fn site_names(&self) -> Vec<String> {
-        self.session
-            .sites()
-            .iter()
-            .map(|a| a.to_string())
-            .collect()
+        self.session.sites().iter().map(|a| a.to_string()).collect()
     }
 
     /// One transition WITH trajectory recording; returns a JSON string of

--- a/crates/fugue-wasm/src/hmc.rs
+++ b/crates/fugue-wasm/src/hmc.rs
@@ -114,6 +114,16 @@ impl WasmHmc {
         accepted
     }
 
+    /// Pin the leapfrog step size (widget slider). Disables adaptation.
+    pub fn set_step_size(&mut self, eps: f64) {
+        self.session.set_step_size(eps);
+    }
+
+    /// Change the number of leapfrog steps per proposal (widget slider).
+    pub fn set_n_leapfrog(&mut self, l: usize) {
+        self.session.set_n_leapfrog(l.clamp(1, 200));
+    }
+
     /// Whether the next step still adapts the step size.
     pub fn is_warming_up(&self) -> bool {
         self.session.is_warming_up()

--- a/crates/fugue-wasm/src/lib.rs
+++ b/crates/fugue-wasm/src/lib.rs
@@ -1,0 +1,1 @@
+//! placeholder

--- a/crates/fugue-wasm/src/lib.rs
+++ b/crates/fugue-wasm/src/lib.rs
@@ -14,12 +14,14 @@
 //! promise a fugue `Trace` makes.
 
 mod dsl;
+mod grid;
 mod hmc;
 mod mh;
 mod pf;
 mod smc;
 
 pub use dsl::CompiledModel;
+pub use grid::log_joint_grid;
 pub use hmc::WasmHmc;
 pub use mh::WasmMh;
 pub use pf::WasmParticleFilter;

--- a/crates/fugue-wasm/src/lib.rs
+++ b/crates/fugue-wasm/src/lib.rs
@@ -1,1 +1,50 @@
-//! placeholder
+//! WebAssembly bindings for fugue: real models, real handlers, real inference
+//! in the browser.
+//!
+//! The docs' interactive widgets and playground drive these types one
+//! animation frame at a time: construct a sampler with a model source (the
+//! `prob!`-subset DSL in [`dsl`]), a JSON data payload, and a seed, then call
+//! `step(n)` per frame and read back draws/diagnostics as typed arrays.
+//! Everything statistical — distributions, trace scoring, MH/HMC transitions,
+//! SMC resampling, R̂/ESS — executes the actual `fugue` crate compiled to
+//! wasm, so the docs cannot drift from the library.
+//!
+//! All samplers are explicitly seeded (`StdRng::seed_from_u64`); no browser
+//! entropy is consumed, and a seed is a replayable recording — the same
+//! promise a fugue `Trace` makes.
+
+mod dsl;
+mod hmc;
+mod mh;
+mod pf;
+mod smc;
+
+pub use dsl::CompiledModel;
+pub use hmc::WasmHmc;
+pub use mh::WasmMh;
+pub use pf::WasmParticleFilter;
+pub use smc::wasm_smc_run;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+}
+
+/// The version of the fugue-wasm bindings package.
+#[wasm_bindgen]
+pub fn fugue_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Validate a model source + data payload without running anything. Returns
+/// the empty string when the model compiles, otherwise the compile error
+/// (with a line number where applicable). Used for live editor feedback.
+#[wasm_bindgen]
+pub fn check_model(source: &str, data_json: &str) -> String {
+    match dsl::CompiledModel::compile(source, data_json) {
+        Ok(_) => String::new(),
+        Err(e) => e,
+    }
+}

--- a/crates/fugue-wasm/src/mh.rs
+++ b/crates/fugue-wasm/src/mh.rs
@@ -1,0 +1,221 @@
+//! Incremental multi-chain adaptive Metropolis-Hastings for the browser.
+//!
+//! Each chain is fugue's real `adaptive_single_site_mh` transition driven one
+//! call at a time, with its own seeded `StdRng` and `DiminishingAdaptation`
+//! state. Histories are kept as full `Trace`s so R̂/ESS come from fugue's own
+//! `diagnostics` module, not a re-implementation.
+
+use fugue::inference::mh::adaptive_single_site_mh;
+use fugue::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use wasm_bindgen::prelude::*;
+
+use crate::dsl::CompiledModel;
+
+struct Chain {
+    rng: StdRng,
+    trace: Trace,
+    adapt: DiminishingAdaptation,
+    history: Vec<Trace>,
+    steps: usize,
+}
+
+/// A set of independent adaptive-MH chains over one compiled model.
+#[wasm_bindgen]
+pub struct WasmMh {
+    model: CompiledModel,
+    chains: Vec<Chain>,
+    // Cap on stored history per chain, so an always-running widget cannot
+    // grow memory without bound. Oldest halves are dropped in blocks.
+    max_history: usize,
+    dropped: usize,
+}
+
+#[wasm_bindgen]
+impl WasmMh {
+    /// Compile `source` (the `prob!`-subset DSL) against `data_json` and
+    /// initialize `n_chains` chains from prior draws, seeded from `seed`
+    /// (chain c uses `seed + c`, so chains are independent but replayable).
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        source: &str,
+        data_json: &str,
+        n_chains: usize,
+        seed: u64,
+    ) -> Result<WasmMh, JsValue> {
+        let model = CompiledModel::compile(source, data_json).map_err(|e| JsValue::from_str(&e))?;
+        let n = n_chains.clamp(1, 16);
+        let chains = (0..n)
+            .map(|c| {
+                let mut rng = StdRng::seed_from_u64(seed.wrapping_add(c as u64));
+                let (_, trace) = fugue::runtime::handler::run(
+                    PriorHandler {
+                        rng: &mut rng,
+                        trace: Trace::default(),
+                    },
+                    model.build(),
+                );
+                Chain {
+                    rng,
+                    trace,
+                    adapt: DiminishingAdaptation::new(0.44, 0.7),
+                    history: Vec::new(),
+                    steps: 0,
+                }
+            })
+            .collect();
+        Ok(WasmMh {
+            model,
+            chains,
+            max_history: 20_000,
+            dropped: 0,
+        })
+    }
+
+    /// Advance every chain by `n` transitions. Returns the total number of
+    /// transitions each chain has taken so far.
+    pub fn step(&mut self, n: usize) -> usize {
+        for chain in &mut self.chains {
+            for _ in 0..n {
+                let (_, next) = adaptive_single_site_mh(
+                    &mut chain.rng,
+                    || self.model.build(),
+                    &chain.trace,
+                    &mut chain.adapt,
+                );
+                chain.trace = next;
+                chain.steps += 1;
+                chain.history.push(chain.trace.clone());
+            }
+        }
+        if self.chains[0].history.len() > self.max_history {
+            let drop = self.max_history / 2;
+            for chain in &mut self.chains {
+                chain.history.drain(0..drop);
+            }
+            self.dropped += drop;
+        }
+        self.chains[0].steps
+    }
+
+    /// Number of chains.
+    pub fn n_chains(&self) -> usize {
+        self.chains.len()
+    }
+
+    /// Total transitions taken per chain.
+    pub fn total_steps(&self) -> usize {
+        self.chains[0].steps
+    }
+
+    /// The `f64` site addresses of the model (from chain 0's current trace),
+    /// in trace order.
+    pub fn site_names(&self) -> Vec<String> {
+        self.chains[0]
+            .trace
+            .choices
+            .iter()
+            .filter(|(_, c)| c.value.as_f64().is_some())
+            .map(|(a, _)| a.to_string())
+            .collect()
+    }
+
+    /// History of a site's values for one chain, from `start` (a step index
+    /// as previously returned by `step`/`total_steps`) onward. Lets the
+    /// renderer pull only the new draws each frame.
+    pub fn values_since(&self, site: &str, chain: usize, start: usize) -> Vec<f64> {
+        let addr = Address::new(site.to_string());
+        let Some(chain) = self.chains.get(chain) else {
+            return Vec::new();
+        };
+        let from = start.saturating_sub(self.dropped);
+        chain
+            .history
+            .iter()
+            .skip(from)
+            .filter_map(|t| t.get_f64(&addr))
+            .collect()
+    }
+
+    /// Current value of a site in each chain (one entry per chain; NaN when
+    /// the site is missing or not `f64`).
+    pub fn current_values(&self, site: &str) -> Vec<f64> {
+        let addr = Address::new(site.to_string());
+        self.chains
+            .iter()
+            .map(|c| c.trace.get_f64(&addr).unwrap_or(f64::NAN))
+            .collect()
+    }
+
+    /// Current total log-weight of each chain.
+    pub fn log_weights(&self) -> Vec<f64> {
+        self.chains
+            .iter()
+            .map(|c| c.trace.total_log_weight())
+            .collect()
+    }
+
+    /// Split-R̂ (Vehtari et al. 2021) across chains for a site, over the last
+    /// `window` retained draws (0 = all retained history). Uses fugue's
+    /// `r_hat_f64`.
+    pub fn r_hat(&self, site: &str, window: usize) -> f64 {
+        let addr = Address::new(site.to_string());
+        let chains: Vec<Vec<Trace>> = self
+            .chains
+            .iter()
+            .map(|c| {
+                let h = &c.history;
+                let from = if window > 0 && h.len() > window {
+                    h.len() - window
+                } else {
+                    0
+                };
+                h[from..].to_vec()
+            })
+            .collect();
+        r_hat_f64(&chains, &addr)
+    }
+
+    /// Multi-chain effective sample size for a site over all retained draws,
+    /// via fugue's `effective_sample_size_multichain`.
+    pub fn ess(&self, site: &str) -> f64 {
+        let addr = Address::new(site.to_string());
+        let values: Vec<Vec<f64>> = self
+            .chains
+            .iter()
+            .map(|c| c.history.iter().filter_map(|t| t.get_f64(&addr)).collect())
+            .collect();
+        effective_sample_size_multichain(&values)
+    }
+
+    /// Overall acceptance rate across chains, from the adaptation's exact
+    /// per-address accept/total counts.
+    pub fn acceptance_rate(&self) -> f64 {
+        let (acc, tot) = self.chains.iter().fold((0usize, 0usize), |(a, t), c| {
+            (
+                a + c.adapt.accept_counts.values().sum::<usize>(),
+                t + c.adapt.total_counts.values().sum::<usize>(),
+            )
+        });
+        if tot == 0 {
+            f64::NAN
+        } else {
+            acc as f64 / tot as f64
+        }
+    }
+
+    /// Posterior summary of a site over retained draws:
+    /// `[mean, std, r_hat, ess]` from fugue's `summarize_f64_parameter`.
+    pub fn summary(&self, site: &str) -> Vec<f64> {
+        let addr = Address::new(site.to_string());
+        let chains: Vec<Vec<Trace>> = self.chains.iter().map(|c| c.history.clone()).collect();
+        let s = summarize_f64_parameter(&chains, &addr);
+        vec![s.mean, s.std, s.r_hat, s.ess]
+    }
+
+    /// Drain runtime model warnings (soft errors mapped to `-inf` regions).
+    pub fn warnings(&self) -> Vec<String> {
+        self.model.take_warnings()
+    }
+}

--- a/crates/fugue-wasm/src/mh.rs
+++ b/crates/fugue-wasm/src/mh.rs
@@ -233,6 +233,27 @@ impl WasmMh {
         }
     }
 
+    /// Overwrite one chain's current value at a site and re-score the trace
+    /// (used when a widget's observed data changes under a live chain: the
+    /// chain keeps its position on the new posterior surface).
+    pub fn set_value(&mut self, chain: usize, site: &str, value: f64) {
+        let addr = Address::new(site.to_string());
+        let model = &self.model;
+        if let Some(c) = self.chains.get_mut(chain) {
+            if let Some(ch) = c.trace.choices.get_mut(&addr) {
+                ch.value = ChoiceValue::F64(value);
+            }
+            let (_, scored) = fugue::runtime::handler::run(
+                ScoreGivenTrace {
+                    base: c.trace.clone(),
+                    trace: Trace::default(),
+                },
+                model.build(),
+            );
+            c.trace = scored;
+        }
+    }
+
     /// Acceptance rate over the last `window` transitions per chain.
     pub fn recent_acceptance(&self, window: usize) -> f64 {
         let (acc, tot) = self.chains.iter().fold((0usize, 0usize), |(a, t), c| {

--- a/crates/fugue-wasm/src/mh.rs
+++ b/crates/fugue-wasm/src/mh.rs
@@ -19,6 +19,8 @@ struct Chain {
     adapt: DiminishingAdaptation,
     history: Vec<Trace>,
     steps: usize,
+    // Rolling accept/reject record (capped) for windowed acceptance readouts.
+    recent: Vec<bool>,
 }
 
 /// A set of independent adaptive-MH chains over one compiled model.
@@ -30,6 +32,10 @@ pub struct WasmMh {
     // grow memory without bound. Oldest halves are dropped in blocks.
     max_history: usize,
     dropped: usize,
+    // When set, every f64 site's proposal scale is pinned to this value
+    // before each transition (fixed-sigma random-walk semantics for the
+    // metropolis explorable's proposal-scale slider). None = adaptive.
+    fixed_scale: Option<f64>,
 }
 
 #[wasm_bindgen]
@@ -62,6 +68,7 @@ impl WasmMh {
                     adapt: DiminishingAdaptation::new(0.44, 0.7),
                     history: Vec::new(),
                     steps: 0,
+                    recent: Vec::new(),
                 }
             })
             .collect();
@@ -70,7 +77,16 @@ impl WasmMh {
             chains,
             max_history: 20_000,
             dropped: 0,
+            fixed_scale: None,
         })
+    }
+
+    /// Pin every site's proposal scale to `sigma` (fixed-sigma random walk;
+    /// the transition kernel is still fugue's `adaptive_single_site_mh`,
+    /// only the scale adaptation is overridden). `sigma <= 0` restores
+    /// adaptive behavior.
+    pub fn set_fixed_scale(&mut self, sigma: f64) {
+        self.fixed_scale = if sigma > 0.0 { Some(sigma) } else { None };
     }
 
     /// Advance every chain by `n` transitions. Returns the total number of
@@ -78,12 +94,24 @@ impl WasmMh {
     pub fn step(&mut self, n: usize) -> usize {
         for chain in &mut self.chains {
             for _ in 0..n {
+                if let Some(sigma) = self.fixed_scale {
+                    let addrs: Vec<Address> = chain.trace.choices.keys().cloned().collect();
+                    for a in addrs {
+                        chain.adapt.scales.insert(a, (sigma, sigma.ln()));
+                    }
+                }
+                let accepted_before: usize = chain.adapt.accept_counts.values().sum();
                 let (_, next) = adaptive_single_site_mh(
                     &mut chain.rng,
                     || self.model.build(),
                     &chain.trace,
                     &mut chain.adapt,
                 );
+                let accepted_after: usize = chain.adapt.accept_counts.values().sum();
+                if chain.recent.len() >= 512 {
+                    chain.recent.drain(0..256);
+                }
+                chain.recent.push(accepted_after > accepted_before);
                 chain.trace = next;
                 chain.steps += 1;
                 chain.history.push(chain.trace.clone());
@@ -197,6 +225,23 @@ impl WasmMh {
                 a + c.adapt.accept_counts.values().sum::<usize>(),
                 t + c.adapt.total_counts.values().sum::<usize>(),
             )
+        });
+        if tot == 0 {
+            f64::NAN
+        } else {
+            acc as f64 / tot as f64
+        }
+    }
+
+    /// Acceptance rate over the last `window` transitions per chain.
+    pub fn recent_acceptance(&self, window: usize) -> f64 {
+        let (acc, tot) = self.chains.iter().fold((0usize, 0usize), |(a, t), c| {
+            let n = c.recent.len().min(window.max(1));
+            let s = c.recent[c.recent.len() - n..]
+                .iter()
+                .filter(|&&x| x)
+                .count();
+            (a + s, t + n)
         });
         if tot == 0 {
             f64::NAN

--- a/crates/fugue-wasm/src/pf.rs
+++ b/crates/fugue-wasm/src/pf.rs
@@ -1,0 +1,183 @@
+//! A 1-D bootstrap particle filter driven by fugue's real SMC primitives.
+//!
+//! The SMC explorable animates particle filtering through time on a
+//! random-walk state-space model. This type keeps the exact semantics of
+//! that widget but computes every statistical step with the fugue crate:
+//! particles are `fugue::Particle`s, transition draws and weight updates use
+//! `Normal::sample`/`log_prob`, normalization is `normalize_particles`, ESS
+//! is `smc::effective_sample_size`, and resampling is fugue's
+//! `systematic_resample` — the same routine `adaptive_smc` uses.
+
+use fugue::inference::smc::{
+    effective_sample_size, normalize_particles, systematic_resample, Particle,
+};
+use fugue::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+fn make_particle(x: f64, log_weight: f64) -> Particle {
+    let mut trace = Trace::default();
+    trace.insert_choice(addr!("x"), ChoiceValue::F64(x), 0.0);
+    Particle {
+        trace,
+        weight: 0.0,
+        log_weight,
+    }
+}
+
+fn positions(particles: &[Particle]) -> Vec<f64> {
+    particles
+        .iter()
+        .map(|p| p.trace.get_f64(&addr!("x")).unwrap_or(f64::NAN))
+        .collect()
+}
+
+#[derive(Serialize)]
+struct StepOut {
+    /// Particle positions before propagation.
+    prev: Vec<f64>,
+    /// Positions after the transition draw.
+    propagated: Vec<f64>,
+    /// Normalized linear weights after the observation update.
+    weights: Vec<f64>,
+    /// ESS / N after weighting (before any resampling).
+    ess_frac: f64,
+    /// Log-evidence increment from this observation.
+    log_z_inc: f64,
+    /// Whether the adaptive threshold triggered resampling.
+    resampled: bool,
+    /// Ancestor index per particle (identity when not resampled).
+    parents: Vec<usize>,
+    /// Final positions after (possible) resampling.
+    posterior: Vec<f64>,
+}
+
+/// Bootstrap particle filter: latent random walk `x_t ~ N(x_{t-1}, sig_step)`
+/// observed through `y_t ~ N(x_t, sig_obs)`.
+#[wasm_bindgen]
+pub struct WasmParticleFilter {
+    particles: Vec<Particle>,
+    rng: StdRng,
+    sig_step: f64,
+    sig_obs: f64,
+    ess_threshold: f64,
+    log_z: f64,
+    t: usize,
+}
+
+#[wasm_bindgen]
+impl WasmParticleFilter {
+    /// `n` particles from the prior `x_0 ~ N(0, prior_sig)`, seeded.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        n: usize,
+        prior_sig: f64,
+        sig_step: f64,
+        sig_obs: f64,
+        ess_threshold: f64,
+        seed: u64,
+    ) -> Result<WasmParticleFilter, JsValue> {
+        let n = n.clamp(2, 5000);
+        let mut rng = StdRng::seed_from_u64(seed);
+        let prior = Normal::new(0.0, prior_sig.max(1e-6))
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let particles = (0..n)
+            .map(|_| make_particle(prior.sample(&mut rng), 0.0))
+            .collect();
+        Ok(WasmParticleFilter {
+            particles,
+            rng,
+            sig_step: sig_step.max(1e-6),
+            sig_obs: sig_obs.max(1e-6),
+            ess_threshold: ess_threshold.clamp(0.0, 1.0),
+            log_z: 0.0,
+            t: 0,
+        })
+    }
+
+    /// The filter's assumed observation noise (widget slider).
+    pub fn set_sig_obs(&mut self, sig_obs: f64) {
+        self.sig_obs = sig_obs.max(1e-6);
+    }
+
+    /// Advance one time step with observation `obs`. Returns a JSON string
+    /// with every intermediate array the animation renders (see `StepOut`).
+    pub fn step(&mut self, obs: f64) -> String {
+        let n = self.particles.len();
+        let prev = positions(&self.particles);
+
+        // Propagate through the transition kernel (bootstrap proposal).
+        let trans_ok = Normal::new(0.0, self.sig_step).unwrap();
+        for p in &mut self.particles {
+            let x = p.trace.get_f64(&addr!("x")).unwrap_or(0.0);
+            let x_new = x + trans_ok.sample(&mut self.rng);
+            p.trace = make_particle(x_new, p.log_weight).trace;
+        }
+        let propagated = positions(&self.particles);
+
+        // Weight by the observation likelihood — fugue's Normal::log_prob.
+        let lik = Normal::new(obs, self.sig_obs).unwrap();
+        for p in &mut self.particles {
+            let x = p.trace.get_f64(&addr!("x")).unwrap_or(0.0);
+            p.log_weight += lik.log_prob(&x);
+        }
+
+        // Log-evidence increment: log mean of the incremental weights. With
+        // equal weights entering the step this is log_sum_exp(lw) - log N.
+        let lws: Vec<f64> = self.particles.iter().map(|p| p.log_weight).collect();
+        let log_z_inc = log_sum_exp(&lws) - (n as f64).ln();
+        self.log_z += log_z_inc;
+
+        normalize_particles(&mut self.particles);
+        let weights: Vec<f64> = self.particles.iter().map(|p| p.weight).collect();
+        let ess = effective_sample_size(&self.particles);
+        let ess_frac = ess / n as f64;
+
+        let resampled = ess_frac < self.ess_threshold;
+        let parents: Vec<usize> = if resampled {
+            let idx = systematic_resample(&mut self.rng, &self.particles);
+            self.particles = idx
+                .iter()
+                .map(|&i| {
+                    let x = self.particles[i].trace.get_f64(&addr!("x")).unwrap_or(0.0);
+                    make_particle(x, 0.0)
+                })
+                .collect();
+            normalize_particles(&mut self.particles);
+            idx
+        } else {
+            // Carry normalized log-weights forward (identity ancestry). The
+            // next step's evidence increment then needs weights relative to
+            // equal, so store log(N·w) — standard weighted-filter bookkeeping.
+            for p in &mut self.particles {
+                p.log_weight = (p.weight * n as f64).max(1e-300).ln();
+            }
+            (0..n).collect()
+        };
+
+        self.t += 1;
+        let out = StepOut {
+            prev,
+            propagated,
+            weights,
+            ess_frac,
+            log_z_inc,
+            resampled,
+            parents,
+            posterior: positions(&self.particles),
+        };
+        serde_json::to_string(&out).unwrap_or_else(|_| "{}".to_string())
+    }
+
+    /// Accumulated log-evidence estimate.
+    pub fn log_evidence(&self) -> f64 {
+        self.log_z
+    }
+
+    /// Time steps taken.
+    pub fn t(&self) -> usize {
+        self.t
+    }
+}

--- a/crates/fugue-wasm/src/pf.rs
+++ b/crates/fugue-wasm/src/pf.rs
@@ -81,8 +81,8 @@ impl WasmParticleFilter {
     ) -> Result<WasmParticleFilter, JsValue> {
         let n = n.clamp(2, 5000);
         let mut rng = StdRng::seed_from_u64(seed);
-        let prior = Normal::new(0.0, prior_sig.max(1e-6))
-            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let prior =
+            Normal::new(0.0, prior_sig.max(1e-6)).map_err(|e| JsValue::from_str(&e.to_string()))?;
         let particles = (0..n)
             .map(|_| make_particle(prior.sample(&mut rng), 0.0))
             .collect();

--- a/crates/fugue-wasm/src/smc.rs
+++ b/crates/fugue-wasm/src/smc.rs
@@ -1,0 +1,88 @@
+//! One-shot adaptive tempered SMC (fugue's `adaptive_smc`) for the
+//! playground: run the full tempering ladder on a compiled model and return
+//! particle values + the unbiased log-evidence estimate.
+
+use fugue::inference::smc::{adaptive_smc, ResamplingMethod, SMCConfig};
+use fugue::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+use crate::dsl::CompiledModel;
+
+#[derive(Serialize)]
+struct SmcOut {
+    /// Per-site posterior particle values: site name -> weighted values.
+    sites: Vec<String>,
+    /// Row per site, matching `sites`: particle values.
+    values: Vec<Vec<f64>>,
+    /// Normalized particle weights (shared across sites).
+    weights: Vec<f64>,
+    log_evidence: f64,
+    ess: f64,
+    warnings: Vec<String>,
+}
+
+/// Run fugue's `adaptive_smc` on a DSL model. Returns a JSON string of
+/// `{sites, values, weights, log_evidence, ess, warnings}`.
+#[wasm_bindgen]
+pub fn wasm_smc_run(
+    source: &str,
+    data_json: &str,
+    n_particles: usize,
+    rejuvenation_steps: usize,
+    seed: u64,
+) -> Result<String, JsValue> {
+    let model = CompiledModel::compile(source, data_json).map_err(|e| JsValue::from_str(&e))?;
+    let mut rng = StdRng::seed_from_u64(seed);
+    let config = SMCConfig {
+        resampling_method: ResamplingMethod::Systematic,
+        ess_threshold: 0.5,
+        rejuvenation_steps: rejuvenation_steps.min(20),
+    };
+    let result = adaptive_smc(
+        &mut rng,
+        n_particles.clamp(10, 5000),
+        || model.build(),
+        config,
+    );
+
+    // Collect the f64 sites present in the first live particle.
+    let sites: Vec<Address> = result
+        .particles
+        .iter()
+        .find(|p| !p.trace.choices.is_empty())
+        .map(|p| {
+            p.trace
+                .choices
+                .iter()
+                .filter(|(_, c)| c.value.as_f64().is_some())
+                .map(|(a, _)| a.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let values: Vec<Vec<f64>> = sites
+        .iter()
+        .map(|a| {
+            result
+                .particles
+                .iter()
+                .map(|p| p.trace.get_f64(a).unwrap_or(f64::NAN))
+                .collect()
+        })
+        .collect();
+    let weights: Vec<f64> = result.particles.iter().map(|p| p.weight).collect();
+    let ess = fugue::inference::smc::effective_sample_size(&result.particles);
+
+    let out = SmcOut {
+        sites: sites.iter().map(|a| a.to_string()).collect(),
+        values,
+        weights,
+        log_evidence: result.log_evidence,
+        ess,
+        warnings: model.take_warnings(),
+    };
+    serde_json::to_string(&out).map_err(|e| JsValue::from_str(&e.to_string()))
+}

--- a/crates/fugue-wasm/tests/wasm.rs
+++ b/crates/fugue-wasm/tests/wasm.rs
@@ -36,7 +36,10 @@ fn mh_recovers_conjugate_posterior_in_wasm() {
     // Determinism: same seed, same draws.
     let mut mh2 = WasmMh::new(COIN, COIN_DATA, 3, 11).unwrap();
     mh2.step(100);
-    assert_eq!(mh.values_since("p", 0, 0)[..100], mh2.values_since("p", 0, 0)[..]);
+    assert_eq!(
+        mh.values_since("p", 0, 0)[..100],
+        mh2.values_since("p", 0, 0)[..]
+    );
 }
 
 #[wasm_bindgen_test]
@@ -76,7 +79,10 @@ fn particle_filter_tracks_and_reports() {
     }
     assert_eq!(pf.t(), 10);
     assert!(pf.log_evidence().is_finite());
-    assert!(resampled_any, "expected at least one resampling in 10 steps");
+    assert!(
+        resampled_any,
+        "expected at least one resampling in 10 steps"
+    );
 }
 
 #[wasm_bindgen_test]

--- a/crates/fugue-wasm/tests/wasm.rs
+++ b/crates/fugue-wasm/tests/wasm.rs
@@ -86,6 +86,51 @@ fn particle_filter_tracks_and_reports() {
 }
 
 #[wasm_bindgen_test]
+fn fixed_scale_and_recent_acceptance() {
+    let mut mh = WasmMh::new(COIN, COIN_DATA, 2, 5).unwrap();
+    mh.set_fixed_scale(0.05); // tiny steps: acceptance should be high
+    mh.step(400);
+    let hi = mh.recent_acceptance(300);
+    let mut mh2 = WasmMh::new(COIN, COIN_DATA, 2, 5).unwrap();
+    mh2.set_fixed_scale(5.0); // huge steps: acceptance should be low
+    mh2.step(400);
+    let lo = mh2.recent_acceptance(300);
+    assert!(hi > lo, "sigma=0.05 acc {hi} should beat sigma=5 acc {lo}");
+    assert!(hi > 0.5, "tiny-step acceptance {hi}");
+}
+
+#[wasm_bindgen_test]
+fn grid_scores_peak_near_posterior_mode() {
+    // 1-D check via a 2-site model; the grid must peak near the conjugate
+    // posterior means.
+    let src = r#"
+        let a <- sample(addr!("a"), Normal(0.0, 2.0));
+        let b <- sample(addr!("b"), Normal(0.0, 2.0));
+        observe(addr!("y"), Normal(a + b, 0.5), 2.0);
+        pure(a)
+    "#;
+    let axis: Vec<f64> = (0..21).map(|i| -2.0 + 0.2 * i as f64).collect();
+    let grid = log_joint_grid(src, "", "a", "b", &axis, &axis, 1).unwrap();
+    assert_eq!(grid.len(), 21 * 21);
+    let (best, _) = grid
+        .iter()
+        .enumerate()
+        .fold((0, f64::NEG_INFINITY), |(bi, bv), (i, &v)| {
+            if v > bv {
+                (i, v)
+            } else {
+                (bi, bv)
+            }
+        });
+    let (a, b) = (axis[best % 21], axis[best / 21]);
+    // Posterior mode of (a, b) is near (0.94, 0.94) for this model.
+    assert!(
+        (a - 1.0).abs() < 0.5 && (b - 1.0).abs() < 0.5,
+        "mode ({a},{b})"
+    );
+}
+
+#[wasm_bindgen_test]
 fn smc_run_returns_evidence() {
     let json = wasm_smc_run(COIN, COIN_DATA, 300, 2, 11).unwrap();
     assert!(json.contains("\"log_evidence\""), "{json}");

--- a/crates/fugue-wasm/tests/wasm.rs
+++ b/crates/fugue-wasm/tests/wasm.rs
@@ -1,0 +1,87 @@
+//! Boundary tests, run in a real wasm runtime via `wasm-pack test --node`.
+
+#![cfg(target_arch = "wasm32")]
+
+use fugue_wasm::*;
+use wasm_bindgen_test::*;
+
+const COIN: &str = r#"
+    let p <- sample(addr!("p"), Beta(2.0, 2.0));
+    for i in 0..data.len() {
+        observe(addr!("flip", i), Bernoulli(p), data[i]);
+    }
+    pure(p)
+"#;
+const COIN_DATA: &str = "[1,0,1,1,0,1,1,0,1,1]"; // 7 heads, 3 tails
+
+#[wasm_bindgen_test]
+fn check_model_reports_errors_and_ok() {
+    assert_eq!(check_model(COIN, COIN_DATA), "");
+    let err = check_model("pure(nope)", "");
+    assert!(err.contains("nope"), "{err}");
+}
+
+#[wasm_bindgen_test]
+fn mh_recovers_conjugate_posterior_in_wasm() {
+    let mut mh = WasmMh::new(COIN, COIN_DATA, 3, 11).unwrap();
+    mh.step(3000);
+    let sites = mh.site_names();
+    assert_eq!(sites, vec!["p".to_string()]);
+    let s = mh.summary("p"); // [mean, std, r_hat, ess]
+    assert!((s[0] - 9.0 / 14.0).abs() < 0.05, "mean {}", s[0]);
+    assert!(s[2] < 1.1, "r_hat {}", s[2]);
+    assert!(s[3] > 50.0, "ess {}", s[3]);
+    let acc = mh.acceptance_rate();
+    assert!(acc > 0.05 && acc < 0.95, "acceptance {acc}");
+    // Determinism: same seed, same draws.
+    let mut mh2 = WasmMh::new(COIN, COIN_DATA, 3, 11).unwrap();
+    mh2.step(100);
+    assert_eq!(mh.values_since("p", 0, 0)[..100], mh2.values_since("p", 0, 0)[..]);
+}
+
+#[wasm_bindgen_test]
+fn hmc_streams_trajectories() {
+    let src = r#"
+        let mu <- sample(addr!("mu"), Normal(0.0, 2.0));
+        for i in 0..data.len() {
+            observe(addr!("y", i), Normal(mu, 1.0), data[i]);
+        }
+        pure(mu)
+    "#;
+    let mut hmc = WasmHmc::new(src, "[1.3, 0.7, 2.1, 0.4, 1.5]", 7, 30, 12, 0.0).unwrap();
+    hmc.step(30); // warmup
+    assert!(!hmc.is_warming_up());
+    let json = hmc.step_recorded();
+    assert!(json.contains("\"trajectory_q\""), "{json}");
+    assert!(json.contains("\"accept_prob\""), "{json}");
+    hmc.step(200);
+    let vals = hmc.values("mu");
+    assert!(vals.len() >= 200);
+    let mean = vals.iter().sum::<f64>() / vals.len() as f64;
+    // Conjugate posterior mean = (sum y / sigma^2) / (1/tau^2 + n/sigma^2) ~ 1.17
+    assert!((mean - 1.17).abs() < 0.4, "mean {mean}");
+}
+
+#[wasm_bindgen_test]
+fn particle_filter_tracks_and_reports() {
+    let mut pf = WasmParticleFilter::new(200, 1.6, 0.7, 0.6, 0.5, 11).unwrap();
+    let mut resampled_any = false;
+    for t in 0..10 {
+        let obs = (t as f64) * 0.3;
+        let json = pf.step(obs);
+        assert!(json.contains("\"posterior\""), "{json}");
+        if json.contains("\"resampled\":true") {
+            resampled_any = true;
+        }
+    }
+    assert_eq!(pf.t(), 10);
+    assert!(pf.log_evidence().is_finite());
+    assert!(resampled_any, "expected at least one resampling in 10 steps");
+}
+
+#[wasm_bindgen_test]
+fn smc_run_returns_evidence() {
+    let json = wasm_smc_run(COIN, COIN_DATA, 300, 2, 11).unwrap();
+    assert!(json.contains("\"log_evidence\""), "{json}");
+    assert!(json.contains("\"p\""), "{json}");
+}

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -18,7 +18,7 @@ preferred-dark-theme = "navy"
 git-repository-url = "https://github.com/alexnodeland/fugue"
 site-url = "/fugue/"
 additional-css = ["./mdbook-admonish.css", "fugue-viz.css"]
-additional-js = ["mermaid.min.js", "mermaid-init.js", "fugue-viz.js", "viz/anatomy.js", "viz/monad.js", "viz/metropolis.js", "viz/hmc.js", "viz/smc.js", "viz/distributions.js", "viz/inline.js", "viz/minis.js"]
+additional-js = ["mermaid.min.js", "mermaid-init.js", "fugue-viz.js", "fugue-wasm-loader.js", "viz/anatomy.js", "viz/monad.js", "viz/metropolis.js", "viz/hmc.js", "viz/smc.js", "viz/distributions.js", "viz/inline.js", "viz/minis.js", "viz/playground.js"]
 
 [output.html.fold]
 enable = true

--- a/docs/fugue-viz.css
+++ b/docs/fugue-viz.css
@@ -401,3 +401,56 @@ html.rust .fv-btn.fv-primary {
     min-width: 0;
   }
 }
+
+/* ==========================================================================
+   Playground (viz/playground.js) — editor, feedback, notice
+   ========================================================================== */
+.fv-pg-editors {
+  margin-bottom: 8px;
+}
+.fv-pg-editor {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 8px;
+  padding: 10px 12px;
+  font-family: var(--mono-font, monospace);
+  font-size: 0.82em;
+  line-height: 1.5;
+  color: var(--fg);
+  background: var(--quote-bg, rgba(128, 128, 128, 0.08));
+  border: 1px solid var(--fv-grid, rgba(128, 128, 128, 0.35));
+  border-radius: 6px;
+  resize: vertical;
+}
+.fv-pg-editor:focus-visible {
+  outline: 2px solid var(--fv-flow, #b18bf5);
+  outline-offset: 1px;
+}
+.fv-pg-feedback {
+  margin-top: 6px;
+  font-family: var(--mono-font, monospace);
+  font-size: 0.75em;
+  min-height: 1.2em;
+}
+.fv-pg-feedback.fv-pg-ok { color: var(--fv-post, #56d364); opacity: 0.8; }
+.fv-pg-feedback.fv-pg-err { color: var(--fv-hot, #ff7b72); }
+.fv-pg-notice {
+  padding: 14px 16px;
+  border: 1px dashed var(--fv-grid, rgba(128, 128, 128, 0.4));
+  border-radius: 8px;
+  font-size: 0.9em;
+  opacity: 0.85;
+}
+.fv-select {
+  font: inherit;
+  font-size: 0.85em;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--fv-grid, rgba(128, 128, 128, 0.35));
+  border-radius: 5px;
+  padding: 3px 6px;
+}
+.fv-pg-badge {
+  margin-top: 6px;
+}

--- a/docs/fugue-wasm-loader.js
+++ b/docs/fugue-wasm-loader.js
@@ -35,7 +35,7 @@
   FV.wasm = null;
   FV.wasmReady = dynImport(root + 'pkg/fugue_wasm.js')
     .then(function (mod) {
-      return mod.default(root + 'pkg/fugue_wasm_bg.wasm').then(function () {
+      return mod.default({ module_or_path: root + 'pkg/fugue_wasm_bg.wasm' }).then(function () {
         FV.wasm = mod;
         try {
           console.log(

--- a/docs/fugue-wasm-loader.js
+++ b/docs/fugue-wasm-loader.js
@@ -1,0 +1,60 @@
+/* fugue-wasm loader — makes the REAL fugue crate available to the doc
+ * widgets and the playground.
+ *
+ * Publishes `FV.wasmReady`, a promise resolving to the wasm-bindgen module
+ * namespace (WasmMh, WasmHmc, WasmParticleFilter, wasm_smc_run,
+ * log_joint_grid, check_model, ...) once `<site>/pkg/fugue_wasm.js` has
+ * loaded and initialized — or to `null` when the package is absent (local
+ * builds without wasm-pack) or the browser cannot load it. Widgets await
+ * this promise at init time and fall back to their mirrored-JS math cores
+ * on `null`, so the docs degrade gracefully.
+ *
+ * Must be listed in book.toml after fugue-viz.js and before viz/*.js.
+ */
+(function () {
+  'use strict';
+  if (!window.FugueViz) return;
+  var FV = window.FugueViz;
+
+  var script =
+    document.currentScript ||
+    document.querySelector('script[src*="fugue-wasm-loader"]');
+  var root = script ? script.src.replace(/fugue-wasm-loader\.js.*$/, '') : './';
+
+  // Dynamic import via Function so browsers without import() support fail
+  // at call time (caught below), not while parsing this whole file.
+  var dynImport;
+  try {
+    dynImport = new Function('u', 'return import(u)');
+  } catch (e) {
+    FV.wasm = null;
+    FV.wasmReady = Promise.resolve(null);
+    return;
+  }
+
+  FV.wasm = null;
+  FV.wasmReady = dynImport(root + 'pkg/fugue_wasm.js')
+    .then(function (mod) {
+      return mod.default(root + 'pkg/fugue_wasm_bg.wasm').then(function () {
+        FV.wasm = mod;
+        try {
+          console.log(
+            '[fugue-viz] fugue-wasm ' +
+              mod.fugue_version() +
+              ' loaded — widgets run the real crate'
+          );
+        } catch (e) { /* readout only */ }
+        return mod;
+      });
+    })
+    .catch(function (e) {
+      try {
+        console.log(
+          '[fugue-viz] fugue-wasm unavailable (' +
+            (e && e.message ? e.message : e) +
+            ') — widgets use the mirrored JS math'
+        );
+      } catch (e2) { /* readout only */ }
+      return null;
+    });
+})();

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,7 @@
   - [Rolling, Not Guessing: HMC](./explorables/hmc.md)
   - [Particles That Tell Stories](./explorables/smc.md)
   - [A Field Guide to Distributions](./explorables/distributions.md)
+- [Playground](./playground.md)
 - [How-To](./how-to/README.md)
   - [Working with Distributions](./how-to/working-with-distributions.md)
   - [Building Complex Models](./how-to/building-complex-models.md)

--- a/docs/src/explorables/README.md
+++ b/docs/src/explorables/README.md
@@ -48,3 +48,10 @@ Once you know it, every canvas and every equation on this site reads at a glance
 Read them in order for a course, or jump to what you came for — each page stands alone and
 links onward. When a page convinces you, the matching tutorial turns the intuition into
 working Rust; the code on every explorable compiles against `fugue-ppl 0.2.0` as written.
+
+One more honesty note, and a point of pride: the samplers behind the MH, HMC, and SMC
+machines are not JavaScript imitations — they are the **fugue crate itself, compiled to
+WebAssembly**, driven one transition per animation frame. Same kernels, same diagnostics,
+same seeded reproducibility as production; only the drawing is JavaScript. (Browsers
+without the WASM package fall back to a faithful JS mirror.) When you want to type your
+own model at these kernels, the **[Playground](../playground.md)** is exactly that.

--- a/docs/src/playground.md
+++ b/docs/src/playground.md
@@ -1,0 +1,84 @@
+# Playground
+
+Everything on this page runs the **real fugue crate**, compiled to
+WebAssembly. The editor below speaks a subset of the `prob!` macro language;
+when you press **Run**, your model text is parsed *in Rust*, folded into
+actual `Model` combinators, and handed to the same inference kernels this
+book documents — adaptive Metropolis–Hastings one transition at a time,
+Hamiltonian Monte Carlo with dual-averaging warmup, adaptive tempered SMC
+with a log-evidence estimate. The draws you watch stream in are fugue's
+draws, not a JavaScript imitation of them.
+
+<div class="fugue-explorable" data-viz="playground" data-seed="11"></div>
+
+## What the editor understands
+
+The playground accepts the statement forms of `prob!`, with data arrays
+provided as JSON (an object of named arrays, or a bare array bound to
+`data`):
+
+```text
+let p <- sample(addr!("p"), Beta(2.0, 2.0));   // sample a latent
+let m = 2.0 * p - 1.0;                          // deterministic let
+observe(addr!("y"), Normal(m, 0.8), 1.4);       // condition on data
+factor(-0.5 * m * m);                           // add a log-weight
+for i in 0..data.len() { ... }                  // plates
+pure(p)                                         // the model's return value
+```
+
+Rust spellings from the docs paste in unchanged — `Normal::new(0.0, 1.0).unwrap()`
+parses the same as `Normal(0.0, 1.0)`. Available distributions: `Normal`,
+`Uniform`, `LogNormal`, `Exponential`, `Beta`, `Gamma`, `InverseGamma`,
+`StudentT`, `Cauchy`, `Laplace`, `Weibull`, `ChiSquared`, `Bernoulli`,
+`Binomial`, `Poisson`, `Categorical`, `DiscreteUniform` — the same
+constructors, parameterizations, and support checks as the crate, because
+they *are* the crate. Expressions know `+ - * /`, `exp`, `ln`, `sqrt`,
+`abs`, `pow`, `min`, `max`, `floor`, `sin`, `cos`, `tanh`, array indexing
+`y[i]`, and `.len()`.
+
+Two honest limitations: parameter regions that would make a distribution
+invalid (say, a negative scale reached through your arithmetic) score as
+impossible (`-inf`) rather than erroring, exactly how the samplers treat
+leaving a support; and the interpreter covers the statement subset above,
+not arbitrary Rust — for that, there is `cargo add fugue-ppl`.
+
+## Things to try
+
+1. **Watch R̂ earn its keep.** Run the coin-flip preset with 3 chains: the
+   chains start from independent prior draws, disagree, then R̂ falls
+   toward 1.00 as their histograms merge — the same split-R̂ computation
+   `fugue::inference::diagnostics` runs in production.
+2. **Break a model, kindly.** Change a flip observation to `2.0` (a coin
+   that landed on its edge?). `Bernoulli` observes a boolean, so anything
+   nonzero coerces to `true` — then make the prior `Beta(0.5, 0.5)` and
+   watch the posterior bend toward the edges.
+3. **Compare kernels on the same posterior.** Run the eight-schools preset
+   under MH, then under HMC. Single-site MH updates one coordinate at a
+   time and mixes slowly through the funnel; HMC moves all ten coordinates
+   jointly. The ESS readout is the receipt.
+4. **Ask for evidence.** Switch to SMC on any preset: you get weighted
+   posterior particles *and* `log Z`, the marginal likelihood MH and HMC
+   never give you.
+5. **Make it yours.** Replace the data JSON with your own numbers. The
+   model recompiles as you type — the ✓/✗ line is fugue's parser talking.
+
+## How this works
+
+`crates/fugue-wasm` (in the fugue repository) exposes wasm-bindgen entry
+points over the crate: compile a model source + data payload, then drive
+`step(n)` per animation frame and read draws and diagnostics back as typed
+arrays. Sampler state lives in Rust — traces, adaptation state, tuned step
+sizes — and every run is seeded, so a seed is a replayable recording here
+too. The interactive figures in the explorables chapters use the same
+package for their samplers; only their canvas rendering is JavaScript.
+
+## Go deeper
+
+- **Explorables:** [Random Walks in Posterior Space](./explorables/metropolis.md),
+  [Rolling, Not Guessing: HMC](./explorables/hmc.md),
+  [Particles That Tell Stories](./explorables/smc.md) — the guided tours of
+  the kernels this playground exposes.
+- **The real thing:** [Installation](./getting-started/installation.md) —
+  `cargo add fugue-ppl` and the full `prob!` language, typed traces,
+  custom handlers.
+- **API:** [docs.rs/fugue-ppl](https://docs.rs/fugue-ppl).

--- a/docs/viz/hmc.js
+++ b/docs/viz/hmc.js
@@ -43,6 +43,13 @@
   var DIV_THRESHOLD = 1000;    // |dH| beyond this => divergent (Stan's default)
   var SPAG_CAP = 60;           // spaghetti lines retained per sampler
 
+  // The SAME regression, written in fugue's model DSL. When the wasm package
+  // is present (FV.wasmReady resolves to the module), the REAL crate compiles
+  // this source and runs the HMC transitions, the MH ghost, the ESS readout
+  // and the heatmap grid. The JS math below stays as the mirrored fallback
+  // core (and as the node-gate export surface).
+  var SRC = 'let a <- sample(addr!("a"), Normal(0.0, 2.5));\nlet b <- sample(addr!("b"), Normal(0.0, 2.5));\nfor i in 0..x.len() {\n    observe(addr!("y", i), Normal(a * x[i] + b, 0.8), y[i]);\n}\npure(a)';
+
   function makeSeedData(seed) {
     var rng = FugueViz.rng(seed >>> 0);
     var xs = new Array(N), ys = new Array(N);
@@ -141,7 +148,15 @@
   // ------------------------------------------------------------------
   if (typeof FugueViz === "undefined" || !FugueViz.register) return;
 
+  // Register a thin async shell: wait for the wasm loader's verdict (module
+  // namespace or null), then init once with the backend fixed for the session.
   FugueViz.register("hmc", function (root, FV) {
+    (FV.wasmReady || Promise.resolve(null)).then(function (W) {
+      realInit(root, FV, W);
+    });
+  });
+
+  function realInit(root, FV, W) {
     var seed0 = parseInt(root.getAttribute("data-seed"), 10);
     if (!isFinite(seed0)) seed0 = DATA_SEED;
 
@@ -161,18 +176,66 @@
 
     function pushCapped(arr, v, cap) { arr.push(v); if (arr.length > cap) arr.shift(); }
 
+    // ---- wasm backend (the real fugue crate) ----
+    // Chosen ONCE at init: W non-null => trajectories, the MH ghost, ESS and
+    // the heatmap grid all come from the crate. Any construction or stepping
+    // failure flips the whole widget back to the mirrored JS core.
+    var useWasm = !!W;
+    var wasmHmc = null, wasmMh = null, warnedFallback = false;
+
+    function dataJson() { return JSON.stringify({ x: data.xs, y: data.ys }); }
+
+    function fallbackToJs(err) {
+      useWasm = false;
+      wasmHmc = null; wasmMh = null;
+      if (!warnedFallback) {
+        warnedFallback = true;
+        try {
+          console.warn("[fugue-viz] hmc: wasm core unavailable, using the mirrored JS math", err);
+        } catch (e2) { /* readout only */ }
+      }
+      root.setAttribute("data-fugue-backend", "js");
+    }
+
+    // (Re)build the wasm chain + MH ghost. Called at init, on reseed, and when
+    // a data point is dragged (the dataset is baked into the wasm objects at
+    // construction). nWarmup = 0: the sliders own the kernel tuning; the chain
+    // starts at a prior draw for the given seed.
+    function rebuildWasm() {
+      if (!useWasm) return;
+      try {
+        if (wasmHmc && wasmHmc.free) wasmHmc.free();
+        if (wasmMh && wasmMh.free) wasmMh.free();
+      } catch (eFree) { /* best-effort release */ }
+      wasmHmc = null; wasmMh = null;
+      try {
+        var dj = dataJson();
+        wasmHmc = new W.WasmHmc(SRC, dj, BigInt(curSeed), 0, L | 0, eps);
+        wasmMh = new W.WasmMh(SRC, dj, 1, BigInt(curSeed));
+        wasmMh.set_fixed_scale(MH_SIGMA);
+        var cva = wasmMh.current_values("a"), cvb = wasmMh.current_values("b");
+        if (cva.length && cvb.length) mhQ = [cva[0], cvb[0]];
+      } catch (e) {
+        fallbackToJs(e);
+      }
+    }
+
+    root.setAttribute("data-fugue-backend", useWasm ? "wasm" : "js");
+
     function resetChain() {
       rng = FV.rng(curSeed);
       q = [0.0, 0.0];
+      mhQ = [0.0, 0.0];
+      if (useWasm) rebuildWasm();   // fresh seed + data; sets mhQ from the ghost
       logpCur = logpost(q[0], q[1], data);
-      trail = [[q[0], q[1]]];
-      samplesA = [q[0]];
       spag = [];
       accepts = 0; total = 0; divergences = 0; lastDH = 0;
-      mhQ = [0.0, 0.0]; mhLogp = logpost(mhQ[0], mhQ[1], data);
+      mhLogp = logpost(mhQ[0], mhQ[1], data);
       mhTrail = [[mhQ[0], mhQ[1]]]; mhSpag = []; mhAccepts = 0; mhTotal = 0;
       active = null; reveal = 0; applied = false; flash = null; rejLine = null;
-      nextTransition();
+      nextTransition();             // wasm: also syncs q to the trajectory start
+      trail = [[q[0], q[1]]];
+      samplesA = [q[0]];
     }
 
     // The data changed (a point was dragged): recompute densities but keep the
@@ -180,12 +243,58 @@
     function onDataChanged() {
       logpCur = logpost(q[0], q[1], data);
       mhLogp = logpost(mhQ[0], mhQ[1], data);
+      // The dataset is baked into the wasm objects at construction, so a drag
+      // must rebuild them (the wasm chain restarts at its seeded prior draw).
+      if (useWasm) rebuildWasm();
       nextTransition();
       bgDirty = true;
     }
 
-    // Simulate a full leapfrog trajectory from the current q using the analytic force.
+    // One HMC transition. wasm mode: the REAL crate runs it (step_recorded)
+    // and we adapt its JSON into the same `active` object the renderer
+    // animates. JS mode: simulate the leapfrog here with the analytic force.
     function nextTransition() {
+      if (useWasm) {
+        try { wasmNextTransition(); return; } catch (e) { fallbackToJs(e); }
+      }
+      jsNextTransition();
+    }
+
+    function wasmNextTransition() {
+      var rec = JSON.parse(wasmHmc.step_recorded());
+      var qs = rec.trajectory_q, Hs = rec.trajectory_h;
+      if (!qs || !qs.length || !Hs || !Hs.length) throw new Error("empty wasm trajectory");
+      // The wasm chain is the source of truth: its trajectory starts at ITS
+      // current position (a retune may have discarded an in-flight transition
+      // that still advanced it), so re-sync q to the recorded start point.
+      q = [qs[0][0], qs[0][1]];
+      var H0 = Hs[0];
+      var last = Hs.length - 1;
+      var dH = Hs[last] - H0;
+      // Apply the widget's own divergence flag (|dH| > DIV_THRESHOLD) on top
+      // of the crate's, so the visual language matches the JS core exactly.
+      var divergent = !!rec.divergent;
+      for (var i = 0; i <= last && !divergent; i++) {
+        if (!isFinite(Hs[i]) || Math.abs(Hs[i] - H0) > DIV_THRESHOLD) divergent = true;
+      }
+      var accept = !!rec.accepted && !divergent;
+      var e0 = rec.step_size > 0 ? rec.step_size : eps;
+      // step_recorded does not return the momentum draw; recover the arrow's
+      // direction from the first leapfrog displacement (q1 - q0 ≈ eps * p0).
+      var p0 = qs.length > 1
+        ? [(qs[1][0] - qs[0][0]) / e0, (qs[1][1] - qs[0][1]) / e0]
+        : [0, 0];
+      var qEnd = qs[qs.length - 1];
+      active = {
+        qs: qs, Hs: Hs, H0: H0, p0: p0, start: [qs[0][0], qs[0][1]],
+        divergent: divergent, dH: dH, accept: accept,
+        qEnd: [qEnd[0], qEnd[1]], logpEnd: logpost(qEnd[0], qEnd[1], data)
+      };
+      reveal = 0; applied = false;
+    }
+
+    // Simulate a full leapfrog trajectory from the current q using the analytic force.
+    function jsNextTransition() {
       var p = [nrm(), nrm()]; // identity mass => N(0,1) momentum
       var U0 = -logpost(q[0], q[1], data);
       var H0 = U0 + 0.5 * (p[0] * p[0] + p[1] * p[1]);
@@ -238,7 +347,24 @@
     }
 
     // Random-walk Metropolis: one proposal per leapfrog step => matched budget.
+    // wasm mode drives the crate's real MH kernel (1 chain, fixed scale); its
+    // single-site kernel needs 2 transitions to approximate 1 joint (a,b) move.
     function mhAdvance(steps) {
+      if (useWasm && wasmMh) {
+        try {
+          for (var j = 0; j < steps; j++) {
+            mhAccepts += wasmMh.step(2);
+            mhTotal += 2;
+            var ga = wasmMh.current_values("a")[0];
+            var gb = wasmMh.current_values("b")[0];
+            mhQ = [ga, gb];
+            pushCapped(mhTrail, [ga, gb], 1200);
+          }
+          mhLogp = logpost(mhQ[0], mhQ[1], data);
+          pushCapped(mhSpag, [mhQ[0], mhQ[1]], SPAG_CAP);
+          return;
+        } catch (e) { fallbackToJs(e); }
+      }
       for (var i = 0; i < steps; i++) {
         var na = mhQ[0] + nrm() * MH_SIGMA;
         var nb = mhQ[1] + nrm() * MH_SIGMA;
@@ -312,7 +438,30 @@
       octx.setTransform(dpr, 0, 0, dpr, 0, 0);
       var xsL = FV.scale(DOM_A, [0, view.w]);
       var ysL = FV.scale(DOM_B, [view.h, 0]);
-      FV.heatmap(octx, function (a, b) { return Math.exp(logpost(a, b, data)); },
+      var field = null;
+      if (useWasm) {
+        // Sample the REAL log-joint on exactly the grid FV.heatmap will ask
+        // for (pixel blocks of `step`, sampled at block centers) and serve
+        // lookups from it — same resolution, and heatmap's max-normalization
+        // keeps the coloring identical to the JS path.
+        try {
+          var step = 4;
+          var cols = Math.ceil(view.w / step), rows = Math.ceil(view.h / step);
+          var aV = new Float64Array(cols), bV = new Float64Array(rows), gi;
+          for (gi = 0; gi < cols; gi++) aV[gi] = xsL.invert(gi * step + step / 2);
+          for (gi = 0; gi < rows; gi++) bV[gi] = ysL.invert(gi * step + step / 2);
+          var grid = W.log_joint_grid(SRC, dataJson(), "a", "b", aV, bV, BigInt(curSeed));
+          field = function (a, b) {
+            var ix = Math.round((xsL(a) - step / 2) / step);
+            var iy = Math.round((ysL(b) - step / 2) / step);
+            if (ix < 0) ix = 0; else if (ix >= cols) ix = cols - 1;
+            if (iy < 0) iy = 0; else if (iy >= rows) iy = rows - 1;
+            return Math.exp(grid[iy * cols + ix]);
+          };
+        } catch (e) { fallbackToJs(e); }
+      }
+      if (!field) field = function (a, b) { return Math.exp(logpost(a, b, data)); };
+      FV.heatmap(octx, field,
         { xscale: xsL, yscale: ysL, w: view.w, h: view.h, colormap: "post", step: 4 });
       view.bg = off;
     }
@@ -571,7 +720,18 @@
       roAccept.set((ar * 100).toFixed(0) + "%", ar >= 0.6 ? "post" : "hot");
       var adH = Math.abs(lastDH);
       roDH.set((lastDH >= 0 ? "+" : "") + lastDH.toFixed(2), adH > 1 ? "hot" : "flow");
-      roEss.set(samplesA.length > 3 ? essSingle(samplesA).toFixed(1) : "—", "post");
+      var essTxt = null;
+      if (samplesA.length > 3) {
+        if (useWasm && wasmHmc) {
+          // fugue's own single-chain ESS over the slope history
+          try {
+            var ev = wasmHmc.ess("a");
+            if (isFinite(ev) && ev > 0) essTxt = ev.toFixed(1);
+          } catch (eE) { /* fall through to the JS estimator */ }
+        }
+        if (essTxt === null) essTxt = essSingle(samplesA).toFixed(1);
+      }
+      roEss.set(essTxt !== null ? essTxt : "—", "post");
       roDiv.set(String(divergences), divergences > 0 ? "hot" : null);
     }
 
@@ -581,12 +741,24 @@
     FV.slider(controls, {
       label: "STEP ε", min: 0.01, max: 0.4, step: 0.005, value: eps,
       fmt: function (v) { return v.toFixed(3); },
-      onInput: function (v) { eps = v; nextTransition(); scheduleDraw(); }
+      onInput: function (v) {
+        eps = v;
+        if (useWasm && wasmHmc) {
+          try { wasmHmc.set_step_size(eps); } catch (e) { fallbackToJs(e); }
+        }
+        nextTransition(); scheduleDraw();
+      }
     });
     FV.slider(controls, {
       label: "LEAPFROG L", min: 1, max: 50, step: 1, value: L,
       fmt: function (v) { return String(v); },
-      onInput: function (v) { L = v | 0; nextTransition(); scheduleDraw(); }
+      onInput: function (v) {
+        L = v | 0;
+        if (useWasm && wasmHmc) {
+          try { wasmHmc.set_n_leapfrog(L); } catch (e) { fallbackToJs(e); }
+        }
+        nextTransition(); scheduleDraw();
+      }
     });
     FV.slider(controls, {
       label: "SPEED", min: 2, max: 40, step: 1, value: speed,
@@ -722,5 +894,5 @@
     // The loop autoplays itself (FV.loop {autoplay:true}); reflect it on the button
     // unless reduced motion (where play() was a no-op and Play is disabled below).
     if (loopApi.playing) playBtn.textContent = "Pause";
-  });
+  }
 })();

--- a/docs/viz/metropolis.js
+++ b/docs/viz/metropolis.js
@@ -574,6 +574,14 @@
       ctx.drawImage(heatCanvas, pp.ix, pp.iy, pp.iw, pp.ih);
       FV.axes(ctx, { x: pp.ix, y: pp.iy, w: pp.iw, h: pp.ih, xscale: pp.sx, yscale: pp.sy, xlabel: "slope a", ylabel: "intercept b", theme: th });
 
+      // Everything walk-related clips to the panel: wasm chains start from
+      // real prior draws, which can lie outside the fixed (a, b) window, and
+      // an unclipped trail would draw over the frame on its way in.
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(pp.ix, pp.iy, pp.iw, pp.ih);
+      ctx.clip();
+
       // param trails (the "recording" so far) — ink, faded
       ctx.save();
       ctx.globalAlpha = 0.45;
@@ -605,6 +613,8 @@
         ctx.beginPath(); ctx.arc(cx, cy, 4.5, 0, 2 * Math.PI); ctx.stroke();
         ctx.restore();
       }
+
+      ctx.restore(); // end param-panel clip
 
       // ---- DATA panel: spaghetti + points ----
       FV.axes(ctx, { x: dp.ix, y: dp.iy, w: dp.iw, h: dp.ih, xscale: dp.sx, yscale: dp.sy, xlabel: "x", ylabel: "y", theme: th });

--- a/docs/viz/metropolis.js
+++ b/docs/viz/metropolis.js
@@ -11,6 +11,9 @@
 // Model: y ~ Normal(a*x + b, 0.8), priors a,b ~ Normal(0, 2.5). σ_obs fixed 0.8.
 // Diagnostics (acceptance / split-R̂ / ESS) ported from src/inference/{diagnostics,
 // mcmc_utils}.rs. Self-contained IIFE; assumes fugue-viz.js has loaded first.
+// Math core: when fugue-wasm-loader.js resolves FV.wasmReady to the real crate,
+// sampling/diagnostics/heatmap run fugue's actual MH kernel via WASM; otherwise
+// the mirrored JS math below runs unchanged (root gets data-fugue-backend=wasm|js).
 (function () {
   "use strict";
   if (typeof window === "undefined" || !window.FugueViz) return;
@@ -19,6 +22,10 @@
   // ---- The model. logp(a,b) is THE log posterior over (slope, intercept). ----
   var SIGMA_OBS = 0.8;   // fixed observation noise (stated on the page)
   var PRIOR_SD = 2.5;    // Normal(0, 2.5) prior on both params
+
+  // The SAME model in the fugue DSL, compiled by the real crate when the wasm
+  // pkg is available. Priors N(0, 2.5), sigma_obs 0.8 — matches logp() below.
+  var SRC = 'let a <- sample(addr!("a"), Normal(0.0, 2.5));\nlet b <- sample(addr!("b"), Normal(0.0, 2.5));\nfor i in 0..x.len() {\n    observe(addr!("y", i), Normal(a * x[i] + b, 0.8), y[i]);\n}\npure(a)';
 
   // Fixed plot domains (kept stable so dragging never makes the axes jump).
   // Windows shared verbatim with viz/hmc.js — the two pages present the SAME
@@ -125,7 +132,15 @@
     return [86, 211, 100];
   }
 
+  // Init defers on FV.wasmReady (fugue-wasm-loader.js): resolves to the
+  // wasm-bindgen module namespace, or null when the pkg is absent — in which
+  // case realInit runs with W=null and behaves exactly as before.
   FV.register("metropolis", function (root, FV) {
+    var p = FV.wasmReady || Promise.resolve(null);
+    p.then(function (W) { realInit(root, FV, W); });
+  });
+
+  function realInit(root, FV, W) {
     // ------------------------------------------------------------------ state
     var seed0 = parseInt(root.getAttribute("data-seed") || "11", 10);
     var params = { sigma: 0.35, nChains: 3, speed: 8, seed: seed0 };
@@ -147,6 +162,160 @@
       return lp;
     }
 
+    // ================================================================= core
+    // ONE math-core interface, two implementations, chosen once at init:
+    // W truthy -> wasmCore (the real fugue crate); W null -> jsCore (the
+    // mirrored JS math above, untouched). A wasm construction error demotes
+    // this widget instance to jsCore permanently. The renderer only ever
+    // consumes chains[].{a,b,lp,trail,as,bs,flash} + spaghetti[] — both
+    // cores feed exactly that state.
+    var mh = null;    // WasmMh instance (wasm core only)
+    var core;         // -> wasmCore or jsCore, selected below
+
+    function dataJson() {
+      return JSON.stringify({
+        x: pts.map(function (p) { return p.x; }),
+        y: pts.map(function (p) { return p.y; })
+      });
+    }
+
+    var warnedFallback = false;
+    function fallbackToJs(err) {
+      if (!warnedFallback) {
+        warnedFallback = true;
+        try { console.warn("[fugue-viz] metropolis: wasm core failed — falling back to JS math", err); } catch (e) { /* readout only */ }
+      }
+      mh = null;
+      core = jsCore;
+      root.setAttribute("data-fugue-backend", "js");
+    }
+
+    var jsCore = {
+      // Dispersed starts + fresh RNG — byte-identical to the pre-wasm widget.
+      reset: function () {
+        rand = FV.rng(params.seed >>> 0);
+        chains = [];
+        for (var i = 0; i < params.nChains; i++) {
+          var a = STARTA[i % 4], b = STARTB[i % 4];
+          chains.push({ a: a, b: b, lp: logp(a, b), as: [a], bs: [b], trail: [[a, b]], flash: null });
+        }
+      },
+      setSigma: function (sigma) { /* doStep reads params.sigma directly */ },
+      step: function () { doStep(); },
+      onDataChanged: function () { reweightChains(); },
+      rhat: function (win) {
+        var as = [], bs = [], i;
+        for (i = 0; i < chains.length; i++) { as.push(chains[i].as); bs.push(chains[i].bs); }
+        var ra = splitRhat(as), rb = splitRhat(bs);
+        var r = Math.max(isFinite(ra) ? ra : -Infinity, isFinite(rb) ? rb : -Infinity);
+        return isFinite(r) ? r : NaN;
+      },
+      ess: function () {
+        var as = [], bs = [], i;
+        for (i = 0; i < chains.length; i++) { as.push(chains[i].as); bs.push(chains[i].bs); }
+        return Math.min(essFromChains(as), essFromChains(bs)); // worst coordinate
+      },
+      acceptRate: function (win) { return accProp ? accAcc / accProp : 0; },
+      heatGrid: function (aVals, bVals) {
+        var na = aVals.length, nb = bVals.length;
+        var out = new Array(na * nb);
+        for (var j = 0; j < nb; j++) {
+          for (var i = 0; i < na; i++) out[j * na + i] = logp(aVals[i], bVals[j]);
+        }
+        return out;
+      }
+    };
+
+    var wasmCore = {
+      reset: function () {
+        try {
+          // u64 args cross wasm-bindgen as BigInt.
+          mh = new W.WasmMh(SRC, dataJson(), params.nChains, BigInt(params.seed));
+          mh.set_fixed_scale(params.sigma);
+        } catch (e) {
+          fallbackToJs(e);
+          core.reset();           // core is jsCore now
+          return;
+        }
+        // Chains start from the crate's own prior draws — real fugue
+        // initialization, intentionally NOT the JS dispersed starts.
+        chains = [];
+        var av = mh.current_values("a"), bv = mh.current_values("b"), lw = mh.log_weights();
+        for (var i = 0; i < params.nChains; i++) {
+          chains.push({ a: av[i], b: bv[i], lp: lw[i], as: [av[i]], bs: [bv[i]], trail: [[av[i], bv[i]]], flash: null });
+        }
+      },
+      setSigma: function (sigma) { if (mh) mh.set_fixed_scale(sigma); },
+      step: function () {
+        // fugue's kernel is single-site adaptive MH: one coordinate per
+        // transition, so 2 transitions ≈ one joint JS move — the walk speed
+        // feels the same at any SPEED setting.
+        mh.step(2);
+        var av = mh.current_values("a"), bv = mh.current_values("b"), lw = mh.log_weights();
+        for (var i = 0; i < chains.length; i++) {
+          var ch = chains[i];
+          var pa = av[i], pb = bv[i];
+          // "accepted" = the chain moved. Rejections have no proposal coords
+          // on this side of the boundary, so their flash sits at the state.
+          var accepted = pa !== ch.a || pb !== ch.b;
+          accProp++;
+          ch.flash = { oa: ch.a, ob: ch.b, pa: pa, pb: pb, accepted: accepted, life: 1 };
+          if (accepted) {
+            accAcc++;
+            spaghetti.push([pa, pb]);
+            if (spaghetti.length > SPAGHETTI) spaghetti.shift();
+          }
+          ch.a = pa; ch.b = pb; ch.lp = lw[i];
+          ch.as.push(ch.a); ch.bs.push(ch.b);
+          if (ch.as.length > MAXSAMP) { ch.as.shift(); ch.bs.shift(); }
+          ch.trail.push([ch.a, ch.b]);
+          if (ch.trail.length > MAXTRAIL) ch.trail.shift();
+        }
+      },
+      onDataChanged: function () {
+        // Posterior moved: rebuild the sampler on the new data but keep every
+        // chain exactly where it stood (set_value re-scores at the position).
+        var saved = [], i;
+        for (i = 0; i < chains.length; i++) saved.push([chains[i].a, chains[i].b]);
+        try {
+          mh = new W.WasmMh(SRC, dataJson(), params.nChains, BigInt(params.seed));
+          mh.set_fixed_scale(params.sigma);
+          for (i = 0; i < saved.length; i++) {
+            mh.set_value(i, "a", saved[i][0]);
+            mh.set_value(i, "b", saved[i][1]);
+          }
+        } catch (e) {
+          fallbackToJs(e);
+          core.onDataChanged();   // jsCore reweights + marks heat dirty
+          return;
+        }
+        var lw = mh.log_weights();
+        for (i = 0; i < chains.length; i++) chains[i].lp = lw[i];
+        heatDirty = true;
+      },
+      rhat: function (win) {
+        // Same readout semantics as jsCore: worst coordinate, split-R̂.
+        var ra = mh.r_hat("a", win || 0), rb = mh.r_hat("b", win || 0);
+        var r = Math.max(isFinite(ra) ? ra : -Infinity, isFinite(rb) ? rb : -Infinity);
+        return isFinite(r) ? r : NaN;
+      },
+      ess: function () { return Math.min(mh.ess("a"), mh.ess("b")); }, // worst coordinate
+      acceptRate: function (win) { return mh.recent_acceptance(win || 0); },
+      heatGrid: function (aVals, bVals) {
+        try {
+          return W.log_joint_grid(SRC, dataJson(), "a", "b",
+            new Float64Array(aVals), new Float64Array(bVals), BigInt(params.seed));
+        } catch (e) {
+          fallbackToJs(e);
+          return core.heatGrid(aVals, bVals);
+        }
+      }
+    };
+
+    core = W ? wasmCore : jsCore;
+    root.setAttribute("data-fugue-backend", W ? "wasm" : "js");
+    // ================================================================ /core
+
     // Seeded default dataset, identical to viz/hmc.js makeSeedData(11):
     // true line y = 0.8·x − 0.4 + Normal(0, 0.8), 12 points evenly on [-3, 3].
     function makeData() {
@@ -163,16 +332,11 @@
     }
 
     function newChains() {
-      rand = FV.rng(params.seed >>> 0);
-      chains = [];
       spaghetti = [];
-      for (var i = 0; i < params.nChains; i++) {
-        var a = STARTA[i % 4], b = STARTB[i % 4];
-        chains.push({ a: a, b: b, lp: logp(a, b), as: [a], bs: [b], trail: [[a, b]], flash: null });
-      }
       accProp = 0; accAcc = 0; acc = 0;
       diag = { rhat: NaN, ess: 0, acc: 0 };
       lastDiag = 0;
+      core.reset();   // rebuilds chains[] (JS: dispersed starts; wasm: prior draws)
     }
 
     // Data changed (drag / reseed): posterior moved, so every chain's cached
@@ -182,6 +346,7 @@
       heatDirty = true;
     }
 
+    // jsCore step: one symmetric joint (a,b) MH proposal per chain.
     function doStep() {
       var s = params.sigma;
       for (var i = 0; i < chains.length; i++) {
@@ -208,13 +373,10 @@
     function refreshDiag(now) {
       if (now - lastDiag < 250) return;
       lastDiag = now;
-      var as = [], bs = [], i;
-      for (i = 0; i < chains.length; i++) { as.push(chains[i].as); bs.push(chains[i].bs); }
-      var ra = splitRhat(as), rb = splitRhat(bs);
-      var rhat = Math.max(isFinite(ra) ? ra : -Infinity, isFinite(rb) ? rb : -Infinity);
-      if (!isFinite(rhat)) rhat = NaN;
-      var ess = Math.min(essFromChains(as), essFromChains(bs)); // worst coordinate
-      diag = { rhat: rhat, ess: ess, acc: accProp ? accAcc / accProp : 0 };
+      // Worst-coordinate split-R̂ over the retained window (JS history is
+      // capped at MAXSAMP, so the wasm core mirrors that), worst-coordinate
+      // ESS, acceptance over everything since the last reset (window 0).
+      diag = { rhat: core.rhat(MAXSAMP), ess: core.ess(), acc: core.acceptRate(0) };
       renderReadouts();
     }
 
@@ -229,7 +391,7 @@
     FV.slider(controls, {
       label: "PROPOSAL σ", min: 0, max: 1, step: 0.001, value: (Math.log(params.sigma) - LOGLO) / (LOGHI - LOGLO),
       fmt: function (t) { return sigmaOf(t).toFixed(2); },
-      onInput: function (t) { params.sigma = sigmaOf(t); requestDraw(); }
+      onInput: function (t) { params.sigma = sigmaOf(t); core.setSigma(params.sigma); requestDraw(); }
     });
 
     FV.slider(controls, {
@@ -299,16 +461,16 @@
       // resolution (4px) once the point is released (onEnd forces heatDirty).
       var step = dragIdx >= 0 ? 8 : 4;
       var cols = Math.ceil(iw / step), rows = Math.ceil(ih / step);
-      var vals = new Array(cols * rows), maxv = -Infinity, ix, iy;
-      for (iy = 0; iy < rows; iy++) {
-        var b = PB[1] - ((iy * step + step / 2) / ih) * (PB[1] - PB[0]);
-        for (ix = 0; ix < cols; ix++) {
-          var a = PA[0] + ((ix * step + step / 2) / iw) * (PA[1] - PA[0]);
-          var v = logp(a, b);
-          if (!isFinite(v)) v = -Infinity;
-          vals[iy * cols + ix] = v;
-          if (v > maxv) maxv = v;
-        }
+      var aVals = new Float64Array(cols), bVals = new Float64Array(rows), ix, iy;
+      for (ix = 0; ix < cols; ix++) aVals[ix] = PA[0] + ((ix * step + step / 2) / iw) * (PA[1] - PA[0]);
+      for (iy = 0; iy < rows; iy++) bVals[iy] = PB[1] - ((iy * step + step / 2) / ih) * (PB[1] - PB[0]);
+      // Row-major log-density grid vals[iy*cols+ix] from the active core —
+      // only the log-density SOURCE differs; normalization/coloring is shared.
+      var vals = core.heatGrid(aVals, bVals);
+      var maxv = -Infinity, k;
+      for (k = 0; k < cols * rows; k++) {
+        var v = vals[k];
+        if (isFinite(v) && v > maxv) maxv = v;
       }
       var rgb = toRgb(col);
       heatCtx.clearRect(0, 0, iw, ih);
@@ -316,7 +478,7 @@
         for (iy = 0; iy < rows; iy++) {
           for (ix = 0; ix < cols; ix++) {
             var lv = vals[iy * cols + ix];
-            var al = lv === -Infinity ? 0 : Math.exp(lv - maxv);
+            var al = isFinite(lv) ? Math.exp(lv - maxv) : 0;
             if (al <= 0.004) continue;
             if (al > 1) al = 1;
             heatCtx.fillStyle = "rgba(" + rgb[0] + "," + rgb[1] + "," + rgb[2] + "," + al + ")";
@@ -518,7 +680,8 @@
         if (nx < DX[0]) nx = DX[0]; if (nx > DX[1]) nx = DX[1];
         if (ny < DY[0]) ny = DY[0]; if (ny > DY[1]) ny = DY[1];
         pts[i].x = nx; pts[i].y = ny;
-        reweightChains();     // posterior moved -> heatDirty + stale lp fixed
+        core.onDataChanged(); // posterior moved -> heatDirty + stale lp fixed
+                              // (wasm: rebuild on new data, chains keep position)
         requestDraw();        // heatmap rebuilds at HALF res while dragging
       },
       onEnd: function () { dragIdx = -1; heatDirty = true; requestDraw(); }
@@ -539,11 +702,11 @@
     // static frame below).
     var FLASH_DUR = 0.35;   // proposal-flash lifetime in seconds (time-based, §A.7)
     var loopApi = FV.loop(root, function (dt) {
-      if (dt === 0) { doStep(); }        // Step button (or reduced-motion)
+      if (dt === 0) { core.step(); }     // Step button (or reduced-motion)
       else {
         acc += dt * params.speed;
         var n = Math.floor(acc);
-        if (n > 0) { acc -= n; if (n > 60) n = 60; for (var i = 0; i < n; i++) doStep(); }
+        if (n > 0) { acc -= n; if (n > 60) n = 60; for (var i = 0; i < n; i++) core.step(); }
         // Decay proposal flashes by wall-clock time, not frame count, so they
         // last the same ~0.35s whether rAF runs at 60fps or drops to 30.
         var dl = dt / FLASH_DUR;
@@ -574,12 +737,12 @@
     // never animates, still shows a rich converged frame — never an empty axis).
     makeData();
     newChains();
-    for (var pw = 0; pw < 40; pw++) doStep();
+    for (var pw = 0; pw < 40; pw++) core.step();
     refreshDiag(nowMs());
     renderReadouts();
     draw();
     // The loop autoplays itself (see FV.loop {autoplay:true}); reflect that on the
     // button. play() already ran and is a no-op under reduced motion.
     if (loopApi.playing) btns.fvButtons["Play"].textContent = "Pause";
-  });
+  }
 })();

--- a/docs/viz/playground.js
+++ b/docs/viz/playground.js
@@ -1,0 +1,518 @@
+/* Playground — edit a fugue model and run REAL fugue inference in the
+ * browser (WebAssembly build of the actual crate; see fugue-wasm-loader.js).
+ *
+ * The editor speaks the prob!-subset DSL compiled by fugue-wasm: the text is
+ * parsed in Rust and folded into real Model combinators, then MH/HMC/SMC run
+ * the crate's actual kernels one animation frame at a time. Nothing on this
+ * page is mirrored JS math; without the wasm package the widget explains
+ * itself instead of pretending.
+ */
+(function () {
+  "use strict";
+  if (!window.FugueViz) return;
+  var FV = window.FugueViz;
+
+  var PRESETS = [
+    {
+      name: "Coin flip (Beta–Bernoulli)",
+      site: "p",
+      source:
+        '// Is this coin fair? A prior belief times ten flips.\n' +
+        'let p <- sample(addr!("p"), Beta(2.0, 2.0));\n' +
+        'for i in 0..data.len() {\n' +
+        '    observe(addr!("flip", i), Bernoulli(p), data[i]);\n' +
+        '}\n' +
+        'pure(p)',
+      data: '[1, 0, 1, 1, 0, 1, 1, 0, 1, 1]'
+    },
+    {
+      name: "Gaussian mean",
+      site: "mu",
+      source:
+        '// Where is the mean? Five observations, known noise.\n' +
+        'let mu <- sample(addr!("mu"), Normal(0.0, 2.0));\n' +
+        'for i in 0..data.len() {\n' +
+        '    observe(addr!("y", i), Normal(mu, 1.0), data[i]);\n' +
+        '}\n' +
+        'pure(mu)',
+      data: '[1.3, 0.7, 2.1, 0.4, 1.5]'
+    },
+    {
+      name: "Linear regression",
+      site: "a",
+      source:
+        '// Slope and intercept, both unknown.\n' +
+        'let a <- sample(addr!("a"), Normal(0.0, 2.5));\n' +
+        'let b <- sample(addr!("b"), Normal(0.0, 2.5));\n' +
+        'for i in 0..x.len() {\n' +
+        '    observe(addr!("y", i), Normal(a * x[i] + b, 0.8), y[i]);\n' +
+        '}\n' +
+        'pure(a)',
+      data:
+        '{"x": [-3, -2.5, -2, -1.5, -1, -0.5, 0.5, 1, 1.5, 2, 2.5, 3],\n' +
+        ' "y": [-2.9, -2.2, -2.1, -1.7, -1.4, -0.9, 0.2, 0.3, 0.9, 1.2, 1.7, 2.1]}'
+    },
+    {
+      name: "Hierarchical (eight schools)",
+      site: "mu",
+      source:
+        '// Partial pooling: eight schools share a population mean.\n' +
+        'let mu <- sample(addr!("mu"), Normal(0.0, 5.0));\n' +
+        'let tau <- sample(addr!("tau"), LogNormal(1.0, 0.5));\n' +
+        'for j in 0..y.len() {\n' +
+        '    let theta <- sample(addr!("theta", j), Normal(mu, tau));\n' +
+        '    observe(addr!("obs", j), Normal(theta, se[j]), y[j]);\n' +
+        '}\n' +
+        'pure(mu)',
+      data:
+        '{"y": [28, 8, -3, 7, -1, 1, 18, 12],\n' +
+        ' "se": [15, 10, 16, 11, 9, 11, 10, 18]}'
+    }
+  ];
+
+  var CHAIN_ROLES = ["post", "hot", "flow", "data"];
+
+  FV.register("playground", function (root) {
+    (FV.wasmReady || Promise.resolve(null)).then(function (W) {
+      init(root, W);
+    });
+  });
+
+  function init(root, W) {
+    root.setAttribute("data-fugue-backend", W ? "wasm" : "none");
+    if (!W) {
+      var note = document.createElement("div");
+      note.className = "fv-pg-notice";
+      note.innerHTML =
+        "The playground runs the <em>real</em> fugue crate compiled to " +
+        "WebAssembly, and that package isn’t available here. On the " +
+        "deployed site it loads automatically; for a local build, run " +
+        "<code>wasm-pack build crates/fugue-wasm --target web --release</code> " +
+        "and copy <code>pkg/</code> next to the book (see the Docs workflow).";
+      root.appendChild(note);
+      return;
+    }
+
+    // ---- Editor ----------------------------------------------------------
+    var editorWrap = mk("div", "fv-pg-editors", root);
+    var presetRow = mk("div", "fv-controls", editorWrap);
+    var presetSel = selectControl(presetRow, "preset", PRESETS.map(function (p) { return p.name; }));
+    var srcTa = mk("textarea", "fv-pg-editor", editorWrap);
+    srcTa.spellcheck = false;
+    srcTa.rows = 8;
+    srcTa.setAttribute("aria-label", "fugue model source");
+    var dataTa = mk("textarea", "fv-pg-editor fv-pg-data", editorWrap);
+    dataTa.spellcheck = false;
+    dataTa.rows = 2;
+    dataTa.setAttribute("aria-label", "observed data (JSON)");
+    var feedback = mk("div", "fv-pg-feedback", editorWrap);
+
+    // ---- Controls --------------------------------------------------------
+    var controls = mk("div", "fv-controls", root);
+    var samplerSel = selectControl(controls, "sampler", ["MH", "HMC", "SMC"]);
+    var chainsSlider = FV.slider(controls, {
+      label: "chains", min: 1, max: 4, step: 1, value: 3,
+      fmt: function (v) { return String(v); },
+      onInput: function () { markDirty(); }
+    });
+    var seedSlider = FV.slider(controls, {
+      label: "seed", min: 1, max: 99, step: 1, value: 11,
+      fmt: function (v) { return String(v); },
+      onInput: function () { markDirty(); }
+    });
+    var siteSel = selectControl(controls, "plot site", []);
+    var btns = FV.buttons(controls, [
+      { label: "Run", primary: true, onClick: onRun },
+      { label: "Pause", onClick: function () { anim.pause(); } },
+      { label: "Reset", onClick: onReset }
+    ]);
+
+    // ---- Plots -----------------------------------------------------------
+    var traceCv = FV.canvas(root, { height: 150 });
+    var histCv = FV.canvas(root, { height: 210 });
+
+    var readouts = mk("div", "fv-readouts", root);
+    var roSteps = FV.readout(readouts, { label: "steps" });
+    var roAcc = FV.readout(readouts, { label: "accept" });
+    var roRhat = FV.readout(readouts, { label: "R̂" });
+    var roEss = FV.readout(readouts, { label: "ESS" });
+    var roZ = FV.readout(readouts, { label: "log Z" });
+    var badge = mk("div", "fv-hint fv-pg-badge", root);
+    badge.textContent =
+      "every draw on this page is computed by the actual fugue crate " +
+      "(fugue-wasm " + safeVersion(W) + ") — same kernels, same seeds, in your browser";
+
+    // ---- State -----------------------------------------------------------
+    var S = {
+      sampler: "MH",       // MH | HMC | SMC
+      mh: null,
+      hmc: null,
+      dirty: true,
+      sites: [],
+      site: null,
+      chains: [],          // per-chain draw arrays for the plotted site
+      warm: 0,             // HMC warmup remaining
+      smc: null,           // parsed SMC result
+      lastError: ""
+    };
+
+    function markDirty() {
+      S.dirty = true;
+      anim.pause();
+    }
+
+    presetSel.onChange(function (idx) {
+      var p = PRESETS[idx];
+      srcTa.value = p.source;
+      dataTa.value = p.data;
+      checkNow();
+      markDirty();
+    });
+    samplerSel.onChange(function () { markDirty(); });
+    siteSel.onChange(function () {
+      S.site = siteSel.value();
+      S.chains = [];
+      if (S.mh) pullAll();
+      draw();
+    });
+
+    var checkTimer = null;
+    function checkSoon() {
+      if (checkTimer) clearTimeout(checkTimer);
+      checkTimer = setTimeout(checkNow, 300);
+      markDirty();
+    }
+    function checkNow() {
+      var err = "";
+      try {
+        err = W.check_model(srcTa.value, dataTa.value);
+      } catch (e) {
+        err = String(e && e.message ? e.message : e);
+      }
+      S.lastError = err;
+      feedback.textContent = err ? "✗ " + err : "✓ model compiles";
+      feedback.className = "fv-pg-feedback" + (err ? " fv-pg-err" : " fv-pg-ok");
+    }
+    srcTa.addEventListener("input", checkSoon);
+    dataTa.addEventListener("input", checkSoon);
+
+    function rebuild() {
+      S.sampler = samplerSel.value();
+      S.mh = null;
+      S.hmc = null;
+      S.smc = null;
+      S.chains = [];
+      S.warm = 0;
+      var seed = BigInt(Math.round(seedSlider.fvGet()));
+      var src = srcTa.value;
+      var dj = dataTa.value;
+      try {
+        if (S.sampler === "MH") {
+          S.mh = new W.WasmMh(src, dj, Math.round(chainsSlider.fvGet()), seed);
+          setSites(toArray(S.mh.site_names()));
+        } else if (S.sampler === "HMC") {
+          S.hmc = new W.WasmHmc(src, dj, seed, 200, 16, 0.0);
+          S.warm = 200;
+          setSites(toArray(S.hmc.site_names()));
+        } else {
+          var json = W.wasm_smc_run(src, dj, 1000, 2, seed);
+          S.smc = JSON.parse(json);
+          setSites(S.smc.sites);
+        }
+        S.dirty = false;
+        return true;
+      } catch (e) {
+        S.lastError = String(e && e.message ? e.message : e);
+        feedback.textContent = "✗ " + S.lastError;
+        feedback.className = "fv-pg-feedback fv-pg-err";
+        return false;
+      }
+    }
+
+    function setSites(names) {
+      S.sites = names;
+      siteSel.setOptions(names);
+      // Prefer the preset's headline site when present.
+      var want = PRESETS[presetSel.index()].site;
+      S.site = names.indexOf(want) >= 0 ? want : names[0] || null;
+      siteSel.set(S.site);
+    }
+
+    function onRun() {
+      checkNow();
+      if (S.lastError) return;
+      if (S.dirty && !rebuild()) return;
+      if (S.sampler === "SMC") {
+        // One-shot: adaptive tempered SMC already ran in rebuild().
+        drawSmc();
+        return;
+      }
+      if (anim.reduced) {
+        // Reduced motion: one explicit batch, one final frame.
+        advance(S.sampler === "MH" ? 1500 : 300);
+        draw();
+        return;
+      }
+      anim.play();
+    }
+
+    function onReset() {
+      anim.pause();
+      S.dirty = true;
+      S.mh = null;
+      S.hmc = null;
+      S.smc = null;
+      S.chains = [];
+      clearCanvas(traceCv);
+      clearCanvas(histCv);
+      setReadouts("—", "—", "—", "—", "—");
+    }
+
+    function advance(n) {
+      if (S.sampler === "MH" && S.mh) {
+        S.mh.step(n);
+        pullAll();
+      } else if (S.sampler === "HMC" && S.hmc) {
+        if (S.warm > 0) {
+          var w = Math.min(S.warm, n);
+          S.hmc.step(w);
+          S.warm -= w;
+        } else {
+          S.hmc.step(n);
+        }
+        S.chains = [toArray(S.hmc.values(S.site))];
+      }
+    }
+
+    function pullAll() {
+      var nc = S.mh.n_chains();
+      for (var c = 0; c < nc; c++) {
+        if (!S.chains[c]) S.chains[c] = [];
+        var got = toArray(S.mh.values_since(S.site, c, S.chains[c].length));
+        for (var i = 0; i < got.length; i++) S.chains[c].push(got[i]);
+      }
+    }
+
+    var anim = FV.loop(root, function () {
+      if (S.sampler === "MH") advance(24);
+      else advance(3);
+      draw();
+    });
+
+    // ---- Rendering -------------------------------------------------------
+    function clearCanvas(cv) {
+      cv.clear();
+    }
+
+    function setReadouts(steps, acc, rhat, ess, z) {
+      roSteps.set(steps);
+      roAcc.set(acc);
+      roRhat.set(rhat, rhat !== "—" && parseFloat(rhat) > 1.1 ? "hot" : "post");
+      roEss.set(ess);
+      roZ.set(z);
+    }
+
+    function pooled() {
+      var all = [];
+      for (var c = 0; c < S.chains.length; c++) {
+        var v = S.chains[c];
+        for (var i = Math.floor(v.length * 0.25); i < v.length; i++) all.push(v[i]);
+      }
+      return all;
+    }
+
+    function draw() {
+      var t = FV.theme();
+      drawTrace(t);
+      drawHist(t, pooled(), null);
+      updateReadouts();
+    }
+
+    function drawTrace(t) {
+      var ctx = traceCv.ctx;
+      traceCv.clear();
+      var pad = { l: 44, r: 10, t: 8, b: 18 };
+      var w = traceCv.w - pad.l - pad.r, h = traceCv.h - pad.t - pad.b;
+      var win = 600;
+      var lo = Infinity, hi = -Infinity, maxLen = 0, c, i;
+      for (c = 0; c < S.chains.length; c++) {
+        var v = S.chains[c];
+        maxLen = Math.max(maxLen, v.length);
+        for (i = Math.max(0, v.length - win); i < v.length; i++) {
+          if (v[i] < lo) lo = v[i];
+          if (v[i] > hi) hi = v[i];
+        }
+      }
+      if (!isFinite(lo)) { lo = -1; hi = 1; }
+      if (hi - lo < 1e-9) { hi = lo + 1; }
+      var pad2 = (hi - lo) * 0.1;
+      var xs = FV.scale([Math.max(0, maxLen - win), Math.max(win, maxLen)], [pad.l, pad.l + w]);
+      var ys = FV.scale([lo - pad2, hi + pad2], [pad.t + h, pad.t]);
+      FV.axes(ctx, { x: pad.l, y: pad.t, w: w, h: h, xscale: xs, yscale: ys, theme: t });
+      for (c = 0; c < S.chains.length; c++) {
+        var vv = S.chains[c];
+        var pts = [];
+        for (i = Math.max(0, vv.length - win); i < vv.length; i++) {
+          pts.push([xs(i), ys(vv[i])]);
+        }
+        FV.curve(ctx, pts, { color: t.colors[CHAIN_ROLES[c % CHAIN_ROLES.length]], width: 1.4 });
+      }
+      label(ctx, t, traceCv, "draws of " + S.site + " (last " + win + ")");
+    }
+
+    function drawHist(t, samples, weights) {
+      var ctx = histCv.ctx;
+      histCv.clear();
+      if (!samples || samples.length === 0) return;
+      var pad = { l: 44, r: 10, t: 10, b: 22 };
+      var w = histCv.w - pad.l - pad.r, h = histCv.h - pad.t - pad.b;
+      var lo = Infinity, hi = -Infinity, i;
+      for (i = 0; i < samples.length; i++) {
+        if (samples[i] < lo) lo = samples[i];
+        if (samples[i] > hi) hi = samples[i];
+      }
+      if (!isFinite(lo) || hi - lo < 1e-9) { lo -= 1; hi += 1; }
+      var span = hi - lo;
+      lo -= span * 0.08;
+      hi += span * 0.08;
+      var bins = 36;
+      var bw = (hi - lo) / bins;
+      var dens = new Array(bins);
+      var wsum = 0;
+      for (i = 0; i < bins; i++) dens[i] = 0;
+      for (i = 0; i < samples.length; i++) {
+        var b = Math.floor((samples[i] - lo) / bw);
+        if (b < 0 || b >= bins) continue;
+        var wt = weights ? weights[i] : 1;
+        dens[b] += wt;
+        wsum += wt;
+      }
+      var maxD = 0;
+      for (i = 0; i < bins; i++) {
+        dens[i] = dens[i] / (wsum * bw || 1);
+        if (dens[i] > maxD) maxD = dens[i];
+      }
+      var xs = FV.scale([lo, hi], [pad.l, pad.l + w]);
+      var ys = FV.scale([0, maxD * 1.12 || 1], [pad.t + h, pad.t]);
+      FV.axes(ctx, { x: pad.l, y: pad.t, w: w, h: h, xscale: xs, yscale: ys, theme: t });
+      ctx.save();
+      ctx.globalAlpha = 0.6;
+      ctx.fillStyle = t.colors.post;
+      for (i = 0; i < bins; i++) {
+        var xa = xs(lo + i * bw), xb = xs(lo + (i + 1) * bw);
+        ctx.fillRect(xa, ys(dens[i]), xb - xa, ys(0) - ys(dens[i]));
+      }
+      ctx.restore();
+      label(ctx, t, histCv, weights ? "posterior of " + S.site + " (weighted particles)" : "posterior of " + S.site);
+    }
+
+    function label(ctx, t, cv, txt) {
+      ctx.save();
+      ctx.fillStyle = t.colors.ink;
+      ctx.globalAlpha = 0.75;
+      ctx.font = "11px var(--mono-font, monospace)";
+      ctx.textAlign = "right";
+      ctx.textBaseline = "top";
+      ctx.fillText(txt, cv.w - 12, 6);
+      ctx.restore();
+    }
+
+    function updateReadouts() {
+      if (S.sampler === "MH" && S.mh) {
+        var rh = S.mh.r_hat(S.site, 0);
+        setReadouts(
+          String(S.mh.total_steps()),
+          fmtP(S.mh.recent_acceptance(500)),
+          isFinite(rh) ? rh.toFixed(3) : "—",
+          Math.round(S.mh.ess(S.site)),
+          "—"
+        );
+      } else if (S.sampler === "HMC" && S.hmc) {
+        setReadouts(
+          (S.chains[0] ? S.chains[0].length : 0) + (S.warm > 0 ? " (warming)" : ""),
+          "ε " + fmtNum(S.hmc.step_size()),
+          "—",
+          S.warm > 0 ? "—" : Math.round(S.hmc.ess(S.site)),
+          "—"
+        );
+      }
+    }
+
+    function drawSmc() {
+      var t = FV.theme();
+      var idx = S.smc.sites.indexOf(S.site);
+      if (idx < 0) idx = 0;
+      clearCanvas(traceCv);
+      drawHist(t, S.smc.values[idx], S.smc.weights);
+      setReadouts(
+        S.smc.values[idx].length + " particles",
+        "—", "—",
+        Math.round(S.smc.ess),
+        S.smc.log_evidence.toFixed(2)
+      );
+    }
+
+    // ---- boot ------------------------------------------------------------
+    presetSel.set(PRESETS[0].name);
+    srcTa.value = PRESETS[0].source;
+    dataTa.value = PRESETS[0].data;
+    checkNow();
+    setReadouts("—", "—", "—", "—", "—");
+  }
+
+  // ---- small helpers -----------------------------------------------------
+  function mk(tag, cls, parent) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (parent) parent.appendChild(e);
+    return e;
+  }
+
+  function toArray(v) {
+    return Array.prototype.slice.call(v || []);
+  }
+
+  function fmtP(v) {
+    return isFinite(v) ? Math.round(v * 100) + "%" : "—";
+  }
+
+  function fmtNum(v) {
+    return isFinite(v) ? (v >= 0.01 ? v.toFixed(3) : v.toExponential(1)) : "—";
+  }
+
+  function safeVersion(W) {
+    try { return W.fugue_version(); } catch (e) { return ""; }
+  }
+
+  // Native <select> wrapped in the fv-control shell so it themes with the
+  // sliders. Returns {el, value(), set(v), onChange(fn), setOptions(list),
+  // index()}.
+  function selectControl(parent, labelTxt, options) {
+    var wrap = mk("label", "fv-control", parent);
+    var lab = mk("span", "fv-control-label", wrap);
+    lab.textContent = labelTxt;
+    var sel = mk("select", "fv-select", wrap);
+    var handler = null;
+    fill(options);
+    function fill(list) {
+      sel.innerHTML = "";
+      for (var i = 0; i < list.length; i++) {
+        var o = document.createElement("option");
+        o.value = list[i];
+        o.textContent = list[i];
+        sel.appendChild(o);
+      }
+    }
+    sel.addEventListener("change", function () {
+      if (handler) handler(sel.selectedIndex);
+    });
+    return {
+      el: wrap,
+      value: function () { return sel.value; },
+      index: function () { return sel.selectedIndex < 0 ? 0 : sel.selectedIndex; },
+      set: function (v) { sel.value = v; },
+      setOptions: fill,
+      onChange: function (fn) { handler = fn; }
+    };
+  }
+})();

--- a/docs/viz/smc.js
+++ b/docs/viz/smc.js
@@ -7,6 +7,14 @@
   if (!window.FugueViz) return;
 
   window.FugueViz.register("smc", function (root, FV) {
+    // Wait for the wasm loader's verdict (module namespace or null), then
+    // init once. When the loader is absent we behave exactly as before.
+    (FV.wasmReady || Promise.resolve(null)).then(function (W) {
+      realInit(root, FV, W);
+    });
+  });
+
+  function realInit(root, FV, W) {
     // ---- fixed model constants --------------------------------------------
     var T = 22; // number of time steps (observations)
     var SIG_STEP = 0.7; // latent random-walk step std (x_t | x_{t-1})
@@ -22,6 +30,49 @@
     };
 
     var colors = FV.theme().colors;
+
+    // ---- wasm backend (real fugue crate) -----------------------------------
+    // When W is non-null the particle-filter math runs in the real crate via
+    // WasmParticleFilter; the JS below stays as the mirrored fallback. The
+    // wasm filter draws its own RNG stream, so a given seed yields a
+    // different — but equally reproducible — particle history than JS mode.
+    var pf = null; // live WasmParticleFilter, or null (JS math)
+    var wasmFailed = false; // construction/step threw once -> permanent JS fallback
+    root.setAttribute("data-fugue-backend", W ? "wasm" : "js");
+
+    function wasmBail(e) {
+      if (!wasmFailed) {
+        try {
+          console.warn(
+            "[fugue-viz] smc: wasm particle filter failed (" +
+              (e && e.message ? e.message : e) +
+              ") — using mirrored JS math"
+          );
+        } catch (e2) { /* readout only */ }
+      }
+      wasmFailed = true;
+      pf = null;
+      root.setAttribute("data-fugue-backend", "js");
+    }
+
+    function buildFilter() {
+      pf = null;
+      if (!W || wasmFailed) return;
+      try {
+        // essThreshold 0 disables resampling (ESS/N is never < 0), which
+        // mirrors the JS path's "adaptive off = never resample" toggle.
+        pf = new W.WasmParticleFilter(
+          st.N,
+          PRIOR_SIG,
+          SIG_STEP,
+          st.sigObs,
+          st.adaptive ? 0.5 : 0,
+          BigInt(st.seed)
+        );
+      } catch (e) {
+        wasmBail(e);
+      }
+    }
 
     // ---- DOM shell ---------------------------------------------------------
     var controls = document.createElement("div");
@@ -105,6 +156,10 @@
         s.push(FV.randn(rand) * PRIOR_SIG); // x_0 prior cloud
         w.push(uni);
       }
+      // wasm mode: fresh filter from the same seed (loop restarts replay).
+      // The JS prior cloud above still paints the at-rest frame; the first
+      // wasm step supplies its own prior via r.prev.
+      buildFilter();
       curT = -1;
       est = [];
       sd = [];
@@ -148,8 +203,101 @@
     }
 
     // -----------------------------------------------------------------------
+    // One time-step through the REAL fugue crate (WasmParticleFilter.step).
+    // Maps the returned JSON onto the exact anim.stp shape the JS path
+    // builds; render-only extras (chosen, jitter) are recomputed here just
+    // as the JS path does.
+    function beginStepWasm() {
+      var toT = curT + 1;
+      if (toT >= T) return false;
+      var n = st.N,
+        i;
+      var hasProp = curT >= 0;
+
+      var r = JSON.parse(pf.step(ys[toT]));
+      var newS = r.propagated;
+      var newW = r.weights; // already normalized
+
+      // posterior mean / weighted variance — same estimator as the JS path
+      var mean = 0;
+      for (i = 0; i < n; i++) mean += newW[i] * newS[i];
+      var vari = 0;
+      for (i = 0; i < n; i++) {
+        var dm = newS[i] - mean;
+        vari += newW[i] * dm * dm;
+      }
+
+      var doResample = !!r.resampled;
+      var parents = doResample ? r.parents : null,
+        postS = doResample ? r.posterior : newS,
+        postW = newW,
+        jitter = null,
+        chosen = null;
+      if (doResample) {
+        chosen = {};
+        for (i = 0; i < n; i++) chosen[parents[i]] = (chosen[parents[i]] || 0) + 1;
+        // deterministic small vertical fan so duplicated children separate
+        jitter = new Array(n);
+        var seen = {};
+        var span = 0.28 * (yDomain[1] - yDomain[0]) * 0.06;
+        for (i = 0; i < n; i++) {
+          var p = parents[i];
+          var k = seen[p] || 0;
+          var cnt = chosen[p];
+          jitter[i] = cnt > 1 ? (k - (cnt - 1) / 2) * span : 0;
+          seen[p] = k + 1;
+        }
+        postW = new Array(n);
+        for (i = 0; i < n; i++) postW[i] = 1 / n;
+      }
+
+      anim.stp = {
+        fromT: curT,
+        toT: toT,
+        hasProp: hasProp,
+        prevS: r.prev,
+        newS: newS,
+        newW: newW,
+        doResample: doResample,
+        parents: parents,
+        chosen: chosen,
+        jitter: jitter,
+        postS: postS,
+        postW: postW,
+        essN: r.ess_frac, // already ESS/N, matching the JS field's units
+        logZ: r.log_z_inc, // incremental log-evidence; finalize accumulates
+        estMean: mean,
+        estVar: vari,
+      };
+      anim.phases = [];
+      anim.durs = [];
+      if (hasProp) {
+        anim.phases.push("propagate");
+        anim.durs.push(DUR.propagate);
+      }
+      anim.phases.push("weight");
+      anim.durs.push(DUR.weight);
+      if (doResample) {
+        anim.phases.push("resample");
+        anim.durs.push(DUR.resample);
+      }
+      anim.time = 0;
+      anim.active = true;
+      return true;
+    }
+
+    // -----------------------------------------------------------------------
     // Compute one full time-step of the filter (pure-ish; commits on finalize).
     function beginStep() {
+      if (pf) {
+        try {
+          return beginStepWasm();
+        } catch (e) {
+          // fall back permanently; s/w are maintained identically in both
+          // modes, so the mirrored JS math continues from the same state.
+          wasmBail(e);
+        }
+      }
       var toT = curT + 1;
       if (toT >= T) return false;
       var n = st.N,
@@ -627,7 +775,18 @@
       },
       onInput: function (v) {
         st.sigObs = v;
-        reset();
+        if (pf) {
+          // wasm mode: retune the live filter mid-run (no reset needed);
+          // any rebuild via reset() picks up st.sigObs anyway.
+          try {
+            pf.set_sig_obs(v);
+          } catch (e) {
+            wasmBail(e);
+            reset();
+          }
+        } else {
+          reset();
+        }
       },
     });
 
@@ -730,5 +889,5 @@
     // autoplay the filter (onPlay is a no-op under reduced motion, which keeps the
     // pre-warmed frame and leaves stepping to the Step button).
     onPlay();
-  });
+  }
 })();

--- a/src/inference/hmc.rs
+++ b/src/inference/hmc.rs
@@ -328,11 +328,27 @@ fn grad_log_joint<A>(
     (g, ok)
 }
 
+/// One recorded point of a leapfrog trajectory: the position `q` over the
+/// continuous sites (ordered as [`HmcSession::sites`]) and the Hamiltonian
+/// `H = -log π(q) + ½ pᵀM⁻¹p` at that point. Produced by
+/// [`HmcSession::step_recorded`]; a rising `h` along a trajectory signals
+/// integration error, and a divergence truncates the recording at the point
+/// the support was left.
+#[derive(Clone, Debug)]
+pub struct LeapfrogPoint {
+    /// Position over the continuous sites.
+    pub q: Vec<f64>,
+    /// Hamiltonian (potential + kinetic energy) at this point.
+    pub h: f64,
+}
+
 /// Leapfrog (velocity-Verlet) integration of the Hamiltonian dynamics for `l`
 /// steps at step size `eps`. The force is reused between the trailing half-kick
 /// of one step and the leading half-kick of the next, so the whole trajectory
 /// costs `L + 1` gradient evaluations. Returns the endpoint `(q, p)` and a
 /// `divergent` flag set when a force evaluation is non-finite (support left).
+/// With `record` attached, each integration point (including the start) is
+/// pushed with its Hamiltonian — one extra model execution per point.
 #[allow(clippy::too_many_arguments)]
 fn leapfrog<A>(
     model_fn: &impl Fn() -> Model<A>,
@@ -344,10 +360,25 @@ fn leapfrog<A>(
     l: usize,
     h: f64,
     m_inv: &[f64],
+    mut record: Option<&mut Vec<LeapfrogPoint>>,
 ) -> (Vec<f64>, Vec<f64>, bool) {
     let d = q0.len();
     let mut q = q0.to_vec();
     let mut p = p0.to_vec();
+
+    // Hamiltonian at the current (q, p); one extra model execution, so only
+    // evaluated when a recorder is attached.
+    let record_point = |q: &[f64], p: &[f64], out: &mut Vec<LeapfrogPoint>| {
+        let k = 0.5 * (0..d).map(|i| p[i] * p[i] * m_inv[i]).sum::<f64>();
+        let lj = log_joint_at(model_fn, base, sites, q);
+        out.push(LeapfrogPoint {
+            q: q.to_vec(),
+            h: -lj + k,
+        });
+    };
+    if let Some(out) = record.as_deref_mut() {
+        record_point(&q, &p, out);
+    }
 
     let (mut grad, ok) = grad_log_joint(model_fn, base, sites, &q, h);
     if !ok {
@@ -368,16 +399,21 @@ fn leapfrog<A>(
         for i in 0..d {
             p[i] += 0.5 * eps * grad[i];
         }
+        if let Some(out) = record.as_deref_mut() {
+            record_point(&q, &p, out);
+        }
     }
     (q, p, false)
 }
 
 /// One HMC transition. Returns
-/// `(accepted, q_next, endpoint_if_accepted, acceptance_probability)`.
+/// `(accepted, q_next, endpoint_if_accepted, acceptance_probability, divergent)`.
 ///
 /// `endpoint_if_accepted` carries the model result, freshly-scored trace, and
-/// log-joint of the accepted state.
-type TransitionOut<A> = (bool, Vec<f64>, Option<(A, Trace, f64)>, f64);
+/// log-joint of the accepted state. `divergent` is set when the trajectory
+/// left the support (non-finite force) or landed on a non-finite log-joint;
+/// a divergent proposal is always rejected with acceptance probability 0.
+type TransitionOut<A> = (bool, Vec<f64>, Option<(A, Trace, f64)>, f64, bool);
 
 #[allow(clippy::too_many_arguments)]
 fn hmc_transition<A: Clone, R: Rng>(
@@ -392,6 +428,7 @@ fn hmc_transition<A: Clone, R: Rng>(
     h: f64,
     m_inv: &[f64],
     mass_sqrt: &[f64],
+    record: Option<&mut Vec<LeapfrogPoint>>,
 ) -> TransitionOut<A> {
     let d = q_cur.len();
 
@@ -405,14 +442,15 @@ fn hmc_transition<A: Clone, R: Rng>(
     let k0 = 0.5 * (0..d).map(|i| p0[i] * p0[i] * m_inv[i]).sum::<f64>();
     let h0 = -lj_cur + k0;
 
-    let (q_new, p_new, divergent) = leapfrog(model_fn, base, sites, q_cur, &p0, eps, l, h, m_inv);
+    let (q_new, p_new, divergent) =
+        leapfrog(model_fn, base, sites, q_cur, &p0, eps, l, h, m_inv, record);
     if divergent {
-        return (false, q_cur.to_vec(), None, 0.0);
+        return (false, q_cur.to_vec(), None, 0.0, true);
     }
 
     let (a_new, t_new, lj_new) = score_full(model_fn, base, sites, &q_new);
     if !lj_new.is_finite() {
-        return (false, q_cur.to_vec(), None, 0.0);
+        return (false, q_cur.to_vec(), None, 0.0, true);
     }
 
     let k_new = 0.5 * (0..d).map(|i| p_new[i] * p_new[i] * m_inv[i]).sum::<f64>();
@@ -422,9 +460,15 @@ fn hmc_transition<A: Clone, R: Rng>(
     let accept_prob = (h0 - h_new).exp().min(1.0);
     let accept = rng.gen::<f64>() < accept_prob;
     if accept {
-        (true, q_new, Some((a_new, t_new, lj_new)), accept_prob)
+        (
+            true,
+            q_new,
+            Some((a_new, t_new, lj_new)),
+            accept_prob,
+            false,
+        )
     } else {
-        (false, q_cur.to_vec(), None, accept_prob)
+        (false, q_cur.to_vec(), None, accept_prob, false)
     }
 }
 
@@ -454,7 +498,7 @@ fn find_reasonable_epsilon<A, R: Rng>(
     let h0 = -lj_q + k0;
 
     let log_ratio_at = |eps: f64| -> f64 {
-        let (q1, p1, divergent) = leapfrog(model_fn, base, sites, q, &p0, eps, 1, h, m_inv);
+        let (q1, p1, divergent) = leapfrog(model_fn, base, sites, q, &p0, eps, 1, h, m_inv, None);
         if divergent {
             return f64::NEG_INFINITY;
         }
@@ -526,21 +570,242 @@ pub fn hmc_chain<A: Clone, R: Rng>(
     n_warmup: usize,
     config: HMCConfig,
 ) -> Vec<(A, Trace)> {
-    // Initialize from a prior draw (correct, fresh accumulators).
-    let (mut cur_a, mut cur_trace) = run(
-        PriorHandler {
-            rng,
-            trace: Trace::default(),
-        },
-        model_fn(),
-    );
-    let (sites, mut q) = positions_from_trace(&cur_trace);
-    let d = sites.len();
+    let mut session = HmcSession::new(rng, &model_fn, n_warmup, config);
+    for _ in 0..n_warmup {
+        session.step(rng, &model_fn);
+    }
+    let mut out = Vec::with_capacity(n_samples);
+    for _ in 0..n_samples {
+        session.step(rng, &model_fn);
+        out.push((session.result().clone(), session.trace().clone()));
+    }
+    out
+}
 
-    // No continuous sites: HMC has nothing to do — return independent prior draws.
-    if d == 0 {
-        let mut out = Vec::with_capacity(n_samples);
-        for _ in 0..n_samples {
+/// Metadata for one [`HmcSession`] transition.
+#[derive(Clone, Debug)]
+pub struct HmcStepInfo {
+    /// Whether the proposal was accepted (the session state advanced).
+    pub accepted: bool,
+    /// Whether the trajectory diverged (non-finite force or log-joint; the
+    /// proposal is always rejected).
+    pub divergent: bool,
+    /// The Metropolis acceptance probability of the proposal (0.0 on
+    /// divergence).
+    pub accept_prob: f64,
+    /// The step size used for this transition.
+    pub step_size: f64,
+    /// The leapfrog trajectory (start point included), recorded only by
+    /// [`HmcSession::step_recorded`]; empty for [`HmcSession::step`]. On a
+    /// divergence the recording stops at the last finite point.
+    pub trajectory: Vec<LeapfrogPoint>,
+}
+
+/// An incremental HMC chain: [`hmc_chain`] exposed one transition at a time.
+///
+/// Holds everything [`hmc_chain`] tracks between transitions — current
+/// position/trace, dual-averaging step-size state, and the (optionally
+/// adapted) diagonal mass matrix — so a caller can advance the chain at its
+/// own pace (an animation frame, a streaming API, an interleaved multi-chain
+/// driver) instead of running to completion. `hmc_chain` itself is a thin
+/// wrapper around this type, so a session stepped `n_warmup + n_samples`
+/// times visits exactly the states the batch chain returns (given the same
+/// RNG stream).
+///
+/// The model is passed to every call (models are single-use; drivers hold a
+/// `Fn() -> Model<A>`), and **must build the same program each time** — same
+/// addresses, same structure — as with every other inference driver in this
+/// crate.
+///
+/// Warmup is handled internally: the first `n_warmup` calls adapt the step
+/// size (and optionally mass) exactly as [`hmc_chain`] does, then the kernel
+/// freezes. [`HmcSession::is_warming_up`] reports which phase the next step
+/// runs in.
+///
+/// # Example
+///
+/// ```rust
+/// use fugue::*;
+/// use fugue::inference::hmc::{HmcSession, HMCConfig};
+/// use rand::rngs::StdRng;
+/// use rand::SeedableRng;
+///
+/// let model_fn = || sample(addr!("x"), Normal::new(0.0, 1.0).unwrap());
+/// let mut rng = StdRng::seed_from_u64(0);
+/// let mut session = HmcSession::new(&mut rng, &model_fn, 50, HMCConfig::default());
+/// for _ in 0..60 {
+///     session.step(&mut rng, &model_fn);
+/// }
+/// let info = session.step_recorded(&mut rng, &model_fn);
+/// assert!(!info.trajectory.is_empty()); // leapfrog path with Hamiltonians
+/// assert!(session.trace().get_f64(&addr!("x")).is_some());
+/// ```
+pub struct HmcSession<A> {
+    sites: Vec<Address>,
+    q: Vec<f64>,
+    cur_a: A,
+    cur_trace: Trace,
+    lj_cur: f64,
+    eps: f64,
+    frozen_eps: Option<f64>,
+    da: DualAveraging,
+    m_inv: Vec<f64>,
+    mass_sqrt: Vec<f64>,
+    welford: Welford,
+    mass_adapt_at: Option<usize>,
+    n_warmup: usize,
+    iter: usize,
+    l: usize,
+    h: f64,
+    target_accept: f64,
+}
+
+impl<A: Clone> HmcSession<A> {
+    /// Initialize a chain from a prior draw, finding a reasonable initial step
+    /// size unless [`HMCConfig::init_step_size`] pins one — identical setup to
+    /// [`hmc_chain`].
+    pub fn new<R: Rng>(
+        rng: &mut R,
+        model_fn: &impl Fn() -> Model<A>,
+        n_warmup: usize,
+        config: HMCConfig,
+    ) -> Self {
+        let (cur_a, cur_trace) = run(
+            PriorHandler {
+                rng,
+                trace: Trace::default(),
+            },
+            model_fn(),
+        );
+        let (sites, q) = positions_from_trace(&cur_trace);
+        let d = sites.len();
+
+        let h = config.finite_diff_eps;
+        let l = config.n_leapfrog.max(1);
+        let m_inv = vec![1.0; d];
+        let mass_sqrt = vec![1.0; d];
+        let lj_cur = cur_trace.total_log_weight();
+
+        // With no continuous sites every step degenerates to a fresh prior
+        // draw; skip the epsilon search (it would divide by d = 0 nowhere,
+        // but there is nothing to tune).
+        let eps0 = if d == 0 {
+            1.0
+        } else {
+            match config.init_step_size {
+                Some(e) => e,
+                None => find_reasonable_epsilon(
+                    rng, model_fn, &cur_trace, &sites, &q, lj_cur, h, &m_inv, &mass_sqrt,
+                ),
+            }
+        };
+        let da = DualAveraging::new(eps0, config.target_accept);
+        let welford = Welford::new(d);
+        let mass_adapt_at = if config.adapt_mass && n_warmup >= 4 {
+            Some(n_warmup / 2)
+        } else {
+            None
+        };
+
+        HmcSession {
+            sites,
+            q,
+            cur_a,
+            cur_trace,
+            lj_cur,
+            eps: eps0,
+            frozen_eps: None,
+            da,
+            m_inv,
+            mass_sqrt,
+            welford,
+            mass_adapt_at,
+            n_warmup,
+            iter: 0,
+            l,
+            h,
+            target_accept: config.target_accept,
+        }
+    }
+
+    /// The ordered continuous site addresses the chain moves (the coordinate
+    /// order of [`HmcSession::position`] and [`LeapfrogPoint::q`]).
+    pub fn sites(&self) -> &[Address] {
+        &self.sites
+    }
+
+    /// The current position over the continuous sites.
+    pub fn position(&self) -> &[f64] {
+        &self.q
+    }
+
+    /// The model result at the current state.
+    pub fn result(&self) -> &A {
+        &self.cur_a
+    }
+
+    /// The current state's trace (freshly scored; `total_log_weight` is valid).
+    pub fn trace(&self) -> &Trace {
+        &self.cur_trace
+    }
+
+    /// The step size the next transition will use.
+    pub fn step_size(&self) -> f64 {
+        if self.iter < self.n_warmup {
+            self.eps
+        } else {
+            self.frozen_or_current()
+        }
+    }
+
+    /// Whether the next [`step`](HmcSession::step) still adapts (warmup phase).
+    pub fn is_warming_up(&self) -> bool {
+        self.iter < self.n_warmup
+    }
+
+    /// Number of transitions taken so far (warmup included).
+    pub fn iterations(&self) -> usize {
+        self.iter
+    }
+
+    fn frozen_or_current(&self) -> f64 {
+        match self.frozen_eps {
+            Some(e) => e,
+            // Freeze lazily on first read past warmup: the dual-averaging
+            // running mean, or the raw eps when there was no warmup —
+            // matching hmc_chain's `final_eps`.
+            None if self.n_warmup > 0 => self.da.frozen_step(),
+            None => self.eps,
+        }
+    }
+
+    /// Advance the chain by one transition. Equivalent to
+    /// [`step_recorded`](HmcSession::step_recorded) without paying for
+    /// trajectory recording.
+    pub fn step<R: Rng>(&mut self, rng: &mut R, model_fn: &impl Fn() -> Model<A>) -> HmcStepInfo {
+        self.advance(rng, model_fn, false)
+    }
+
+    /// Advance the chain by one transition, recording the leapfrog trajectory
+    /// and the Hamiltonian at each integration point (one extra model
+    /// execution per point — meant for visualization and diagnostics, not
+    /// hot loops).
+    pub fn step_recorded<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        model_fn: &impl Fn() -> Model<A>,
+    ) -> HmcStepInfo {
+        self.advance(rng, model_fn, true)
+    }
+
+    fn advance<R: Rng>(
+        &mut self,
+        rng: &mut R,
+        model_fn: &impl Fn() -> Model<A>,
+        record: bool,
+    ) -> HmcStepInfo {
+        // No continuous sites: independent prior draws, as in hmc_chain.
+        if self.sites.is_empty() {
             let (a, t) = run(
                 PriorHandler {
                     rng,
@@ -548,90 +813,92 @@ pub fn hmc_chain<A: Clone, R: Rng>(
                 },
                 model_fn(),
             );
-            out.push((a, t));
+            self.cur_a = a;
+            self.lj_cur = t.total_log_weight();
+            self.cur_trace = t;
+            self.iter += 1;
+            return HmcStepInfo {
+                accepted: true,
+                divergent: false,
+                accept_prob: 1.0,
+                step_size: self.eps,
+                trajectory: Vec::new(),
+            };
         }
-        return out;
-    }
 
-    let h = config.finite_diff_eps;
-    let l = config.n_leapfrog.max(1);
+        let warming = self.iter < self.n_warmup;
+        let eps = if warming {
+            self.eps
+        } else {
+            let e = self.frozen_or_current();
+            self.frozen_eps = Some(e);
+            e
+        };
 
-    // Mass matrix: identity by default. m_inv = M^{-1} diagonal; mass_sqrt = √M.
-    let mut m_inv = vec![1.0; d];
-    let mut mass_sqrt = vec![1.0; d];
-
-    let mut lj_cur = cur_trace.total_log_weight();
-
-    let eps0 = match config.init_step_size {
-        Some(e) => e,
-        None => find_reasonable_epsilon(
-            rng, &model_fn, &cur_trace, &sites, &q, lj_cur, h, &m_inv, &mass_sqrt,
-        ),
-    };
-    let mut da = DualAveraging::new(eps0, config.target_accept);
-    let mut eps = eps0;
-
-    let mut welford = Welford::new(d);
-    // Adapt the mass matrix once, at the warmup midpoint, when requested.
-    let mass_adapt_at = if config.adapt_mass && n_warmup >= 4 {
-        Some(n_warmup / 2)
-    } else {
-        None
-    };
-
-    // -- Warmup: adapt step size (and optionally mass). --
-    for iter in 0..n_warmup {
-        let (accepted, q_new, endpoint, alpha) = hmc_transition(
-            rng, &model_fn, &cur_trace, &sites, &q, lj_cur, eps, l, h, &m_inv, &mass_sqrt,
+        let mut trajectory = Vec::new();
+        let recorder = if record { Some(&mut trajectory) } else { None };
+        let (accepted, q_new, endpoint, alpha, divergent) = hmc_transition(
+            rng,
+            model_fn,
+            &self.cur_trace,
+            &self.sites,
+            &self.q,
+            self.lj_cur,
+            eps,
+            self.l,
+            self.h,
+            &self.m_inv,
+            &self.mass_sqrt,
+            recorder,
         );
         if accepted {
             let (a, t, lj) = endpoint.unwrap();
-            cur_a = a;
-            cur_trace = t;
-            q = q_new;
-            lj_cur = lj;
+            self.cur_a = a;
+            self.cur_trace = t;
+            self.q = q_new;
+            self.lj_cur = lj;
         }
-        eps = da.update(alpha);
 
-        if mass_adapt_at.is_some() {
-            welford.push(&q);
-        }
-        if Some(iter + 1) == mass_adapt_at {
-            // Set M^{-1} to the estimated marginal variances and re-tune eps for
-            // the remaining warmup. Any positive diagonal mass keeps the kernel
-            // exact (module docs), so this only affects efficiency.
-            let vars = welford.variances();
-            for i in 0..d {
-                m_inv[i] = vars[i];
-                mass_sqrt[i] = (1.0 / vars[i]).sqrt();
+        if warming {
+            self.eps = self.da.update(alpha);
+            if self.mass_adapt_at.is_some() {
+                self.welford.push(&self.q);
             }
-            let eps_reset = find_reasonable_epsilon(
-                rng, &model_fn, &cur_trace, &sites, &q, lj_cur, h, &m_inv, &mass_sqrt,
-            );
-            da = DualAveraging::new(eps_reset, config.target_accept);
-            eps = eps_reset;
+            if Some(self.iter + 1) == self.mass_adapt_at {
+                // Set M^{-1} to the estimated marginal variances and re-tune
+                // eps for the remaining warmup. Any positive diagonal mass
+                // keeps the kernel exact (module docs), so this only affects
+                // efficiency.
+                let vars = self.welford.variances();
+                for (i, &v) in vars.iter().enumerate() {
+                    self.m_inv[i] = v;
+                    self.mass_sqrt[i] = (1.0 / v).sqrt();
+                }
+                let eps_reset = find_reasonable_epsilon(
+                    rng,
+                    model_fn,
+                    &self.cur_trace,
+                    &self.sites,
+                    &self.q,
+                    self.lj_cur,
+                    self.h,
+                    &self.m_inv,
+                    &self.mass_sqrt,
+                );
+                self.da = DualAveraging::new(eps_reset, self.target_accept);
+                self.eps = eps_reset;
+            }
+        }
+        self.iter += 1;
+
+        HmcStepInfo {
+            accepted,
+            divergent,
+            accept_prob: alpha,
+            step_size: eps,
+            trajectory,
         }
     }
-
-    // Freeze the step size (dual-averaging running mean) after warmup.
-    let final_eps = if n_warmup > 0 { da.frozen_step() } else { eps };
-
-    // -- Sampling: fixed kernel. --
-    let mut out = Vec::with_capacity(n_samples);
-    for _ in 0..n_samples {
-        let (accepted, q_new, endpoint, _alpha) = hmc_transition(
-            rng, &model_fn, &cur_trace, &sites, &q, lj_cur, final_eps, l, h, &m_inv, &mass_sqrt,
-        );
-        if accepted {
-            let (a, t, lj) = endpoint.unwrap();
-            cur_a = a;
-            cur_trace = t;
-            q = q_new;
-            lj_cur = lj;
-        }
-        out.push((cur_a.clone(), cur_trace.clone()));
-    }
-    out
 }
 
 #[cfg(test)]
@@ -732,5 +999,72 @@ mod tests {
         assert!(my.abs() < 2.0, "y mean {my}");
         assert!((vx - 1.0).abs() < 0.25, "var(x) {vx}");
         assert!((vy - 100.0).abs() < 25.0, "var(y) {vy}");
+    }
+
+    // The incremental session must visit exactly the states the batch chain
+    // returns: same seed, same model, same config => identical draws. This
+    // pins hmc_chain as a true thin wrapper over HmcSession.
+    #[test]
+    fn session_matches_batch_chain_exactly() {
+        let model_fn = || {
+            sample(addr!("mu"), Normal::new(0.0, 1.0).unwrap())
+                .bind(|mu| observe(addr!("y"), Normal::new(mu, 1.0).unwrap(), 2.0).map(move |_| mu))
+        };
+        let cfg = HMCConfig::default();
+        let (n_warmup, n_samples) = (50, 40);
+
+        let mut rng1 = StdRng::seed_from_u64(7);
+        let batch = hmc_chain(&mut rng1, model_fn, n_samples, n_warmup, cfg);
+
+        let mut rng2 = StdRng::seed_from_u64(7);
+        let mut session = HmcSession::new(&mut rng2, &model_fn, n_warmup, cfg);
+        for _ in 0..n_warmup {
+            assert!(session.is_warming_up());
+            session.step(&mut rng2, &model_fn);
+        }
+        for (batch_mu, batch_trace) in &batch {
+            assert!(!session.is_warming_up());
+            session.step(&mut rng2, &model_fn);
+            assert_eq!(*session.result(), *batch_mu);
+            assert_eq!(
+                session.trace().total_log_weight(),
+                batch_trace.total_log_weight()
+            );
+        }
+    }
+
+    // step_recorded returns the full leapfrog path (L+1 points, start
+    // included) with finite Hamiltonians, and recording must not perturb the
+    // chain: the extra Hamiltonian evaluations are deterministic re-scores
+    // that consume no randomness.
+    #[test]
+    fn recorded_trajectory_shape_and_rng_neutrality() {
+        let model_fn = || {
+            sample(addr!("mu"), Normal::new(0.0, 1.0).unwrap())
+                .bind(|mu| observe(addr!("y"), Normal::new(mu, 1.0).unwrap(), 0.5).map(move |_| mu))
+        };
+        let cfg = HMCConfig {
+            n_leapfrog: 12,
+            init_step_size: Some(0.2),
+            ..HMCConfig::default()
+        };
+
+        let mut rng1 = StdRng::seed_from_u64(3);
+        let mut recorded = HmcSession::new(&mut rng1, &model_fn, 0, cfg);
+        let mut rng2 = StdRng::seed_from_u64(3);
+        let mut plain = HmcSession::new(&mut rng2, &model_fn, 0, cfg);
+
+        for _ in 0..10 {
+            let info = recorded.step_recorded(&mut rng1, &model_fn);
+            plain.step(&mut rng2, &model_fn);
+            if !info.divergent {
+                assert_eq!(info.trajectory.len(), cfg.n_leapfrog + 1);
+            }
+            for pt in &info.trajectory {
+                assert_eq!(pt.q.len(), 1);
+                assert!(pt.h.is_finite());
+            }
+            assert_eq!(recorded.position(), plain.position());
+        }
     }
 }

--- a/src/inference/hmc.rs
+++ b/src/inference/hmc.rs
@@ -734,6 +734,24 @@ impl<A: Clone> HmcSession<A> {
         &self.sites
     }
 
+    /// Pin the step size for all subsequent transitions, overriding both
+    /// warmup adaptation and the frozen dual-averaging value. Meant for
+    /// interactive use (a step-size slider); the kernel stays exact for any
+    /// positive `eps`.
+    pub fn set_step_size(&mut self, eps: f64) {
+        let eps = eps.max(1e-12);
+        self.eps = eps;
+        self.frozen_eps = Some(eps);
+        // Leave warmup: a manually pinned step size must not be re-adapted.
+        self.n_warmup = self.n_warmup.min(self.iter);
+    }
+
+    /// Change the number of leapfrog steps per proposal for subsequent
+    /// transitions.
+    pub fn set_n_leapfrog(&mut self, l: usize) {
+        self.l = l.max(1);
+    }
+
     /// The current position over the continuous sites.
     pub fn position(&self) -> &[f64] {
         &self.q

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub use inference::diagnostics::{
     extract_u64_values, extract_usize_values, print_diagnostics, r_hat_f64,
     summarize_f64_parameter, Diagnostics, ParameterSummary,
 };
-pub use inference::hmc::{hmc_chain, HMCConfig};
+pub use inference::hmc::{hmc_chain, HMCConfig, HmcSession, HmcStepInfo, LeapfrogPoint};
 pub use inference::mcmc_utils::{
     effective_sample_size_mcmc, effective_sample_size_multichain, geweke_diagnostic,
     DiminishingAdaptation,


### PR DESCRIPTION
Closes #40.

The docs now run the **actual fugue crate** in the browser. A new in-tree bindings crate (\`crates/fugue-wasm\`, mirroring fugue-evo's wasm-crate arrangement) compiles the library to WebAssembly; the explorables' MH/HMC/SMC widgets drive it one transition per animation frame, and a new **Playground** page lets readers edit a \`prob!\`-subset model and run MH, HMC, or SMC on it — real kernels, real diagnostics, real seeded traces. The mirrored JS math survives only as an automatic fallback.

## Core library
- **\`HmcSession\`** (new public API in \`inference::hmc\`): incremental HMC — one transition at a time, optional leapfrog-trajectory recording with per-point Hamiltonians, live \`set_step_size\`/\`set_n_leapfrog\`. \`hmc_chain\` is now a thin wrapper; a test pins same-seed equivalence with the old batch behavior. (MH already had \`adaptive_single_site_mh\`; SMC's primitives were already public.)

## crates/fugue-wasm (unpublished workspace member)
- **DSL**: parses a Rust-ish \`prob!\` subset (\`let x <- sample(addr!(..), Dist(..))\`, \`observe\`, \`factor\`, \`for\`/plates, \`pure\`; \`Dist::new(..).unwrap()\` sugar accepted) and folds it into real \`Model\` combinators. Addresses use fugue's own \`make_name\`/\`make_indexed\`, so they match \`addr!\` byte-for-byte. All 17 distributions. Soft runtime errors (invalid params, OOB index) degrade to \`factor(-inf)\` + a warning — no panics at the JS boundary.
- **\`WasmMh\`** — multi-chain incremental adaptive MH; R̂/ESS/summaries from fugue's \`diagnostics\`; \`set_fixed_scale\` (the metropolis page teaches the proposal-σ tradeoff), \`set_value\` (chains survive live data edits).
- **\`WasmHmc\`** — incremental HMC over \`HmcSession\`; \`step_recorded()\` streams trajectories.
- **\`WasmParticleFilter\`** — bootstrap filter computed with fugue's \`Particle\`, \`Normal::log_prob\`, \`normalize_particles\`, ESS, \`systematic_resample\`.
- **\`wasm_smc_run\`** — one-shot adaptive tempered SMC with log-evidence. **\`log_joint_grid\`** — heatmaps scored by \`ScoreGivenTrace\` (the exact surface the samplers walk).
- Everything explicitly seeded (\`StdRng\`); no browser entropy. 440 KB wasm after \`wasm-opt -Os\`.

## Docs
- **Playground page**: editor with live Rust-parser feedback (\`check_model\`), 4 presets (coin, Gaussian mean, regression, eight schools), streaming trace + posterior plots, R̂/ESS/acceptance/log-evidence readouts; explains itself when the pkg is absent.
- **Widget swaps** (\`metropolis\`, \`hmc\`, \`smc\`): renderers untouched; math cores select wasm/JS once at init via \`FV.wasmReady\` and stamp \`data-fugue-backend\` for testability. Honest wasm-mode differences: chains start from real prior draws, and MH moves are single-site (fugue's actual kernel). The \`sigma-sweep\` mini stays JS (it needs fixed-σ chains fugue's public API doesn't expose; noted for a follow-up).
- Explorables README now states the samplers are the real crate; loader + \`pkg/\` embedding wired into the Docs workflow; CI gains a wasm job (check + native tests + \`wasm-pack test --node\` + release build); the MSRV job excludes the bindings crate (wasm-bindgen has its own floor).

## Validation
- 13 native + 9 wasm-runtime (Node) tests: interpreted coin model recovers Beta(9,5) posterior mean under real MH; grid peaks at the posterior mode; fixed-scale acceptance ordering; determinism.
- Headless Playwright against the built book + pkg: all 35 pages error-free, no blank canvases; all three widgets on \`backend=wasm\`; playground MH (R̂→1.00, ESS thousands), HMC on eight schools, SMC evidence; drag + MH-ghost interactions clean.
- End-to-end fidelity check: the playground's SMC \`log Z\` on the coin preset is **−6.98**, matching the analytic marginal likelihood \`ln[B(9,5)/B(2,2)] = −6.98\` exactly.

Companion for evo: alexnodeland/fugue-evo#12 + #13 (evo explorables to be WASM-backed from day one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yo1jdkckG7yQ9eBqLbaDB