### PR TITLE
EA-as-PPL upstream primitives (F1–F6): population kernels, block regeneration, trace surgery — fugue-ppl 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,72 @@ For the initial 0.1.0 release notes, see `.github/CHANGELOG.md`.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-28
+
+EA-as-PPL upstream primitives (F1-F6 of the cross-repo plan, tracking issue
+[#44](https://github.com/alexnodeland/fugue/issues/44)): the additive machinery
+that lets an evolutionary-computation layer run genuinely PPL-native inference
+- population-coupled SMC moves, block regeneration, and trace surgery.
+
 ### Added
+
+- **Population-coupled SMC kernels (F4)**: object-safe `PopulationKernel<A>`
+  trait with the pi_beta-product invariance contract (W/T/S/E) documented on
+  the trait; `NoKernel` identity kernel; generic mask-driven `CrossoverKernel`
+  (pairwise block-swap Metropolis move on the product target - a symmetric
+  involution, Hastings ratio 1); and `adaptive_smc_with_kernel`, which invokes
+  the kernel after each intermediate resample + rejuvenation and never at the
+  terminal beta = 1 step (FG-43). `adaptive_smc` is now defined as
+  `adaptive_smc_with_kernel(.., &mut NoKernel)` with its signature unchanged.
+  Pinned by product-invariance, weight-preservation (bit-identical across a
+  sweep), log-evidence non-corruption vs analytic marginal likelihood (FG-58),
+  and joint-support truncation tests.
+- **Block-regeneration MH (F2)**: `block_regeneration_mh` - delete the choices
+  at an address set S, replay the model via `score_given_trace_reconciled`
+  (fresh prior draws at S), and accept with the prior-cancelling ratio
+  including fresh/vanished RJMCMC bookkeeping. For fixed structure the ratio
+  collapses to `beta * delta-loglik`. Note: unlike the single-site kernels
+  there is deliberately **no dimension-selection term** - the block is fixed by
+  the caller, not selected uniformly from a state-dependent site set. Pinned by
+  conjugate Beta-Bernoulli validation, product-Normal analytic posterior,
+  trans-dimensional switch-gated-branch analytic posterior, and fresh-rescore
+  equality (FG-48) tests.
+- **Trace subtree surgery (F3)**: boundary-aware `Address::has_prefix`
+  (recognizes `#`, `::`, `/` segment separators; does not treat `"gene"` as a
+  prefix of `"generation"`) and `Trace::{extract_prefix, truncate_prefix,
+  graft_prefix}`. All three deliberately leave the flat, non-address-keyed log
+  accumulators zeroed/stale - the only correct recomputation is a model
+  re-score, which the F2/F4 kernels perform. Pinned by boundary, round-trip,
+  graft-then-rescore-equality, and accumulator-zeroing tests.
+- **Decode-replay helpers (F5)**: `decode_particle` / `decode_particles`
+  recover the model return value (e.g. a decoded genome) from a particle trace
+  by replaying under `ScoreGivenTrace`; fallible `try_decode_particle` (backed
+  by `SafeScoreGivenTrace`) for traces of uncertain provenance. `Particle`
+  deliberately does not cache the return value (would force `A: Clone` through
+  resampling and break the FG-59 move-not-clone construction).
+- **Crate-root re-export widening (F6)**: `SMCResult` (previously returned by
+  `adaptive_smc` yet unreachable by name from the root), `smc_prior_particles`,
+  `normalize_particles`, `resample_particles`, `rejuvenate_particles`,
+  `systematic_resample`, `stratified_resample`, `multinomial_resample`,
+  `score_given_trace_reconciled`, `ReconcileReport`, plus all new F2/F4/F5
+  items. Pinned by a root-import integration test.
+
+### Fixed
+
+- **SMC rejuvenation now moves non-F64 sites (F1)**: `tempered_single_site_mh`
+  previously collected only `ChoiceValue::F64` sites and returned
+  `current.clone()` otherwise, so a population of pure Bool/U64/Usize traces
+  (bit-string or permutation genomes) was silently frozen during rejuvenation.
+  It now picks the target uniformly over all sites and dispatches by value type
+  through the same typed proposal machinery as `adaptive_single_site_mh`
+  (flip for Bool, reflected discrete walk for U64, prior-resample for Usize,
+  integer walk for I64, Gaussian/log-space walk for F64), with the tempered
+  trans-dimensional acceptance
+  `delta-log-prior + beta * delta-loglik + (log q_rev - log q_fwd) + dim_term`.
+  Pinned by a Bool-population movement regression and an independent-Bernoulli
+  analytic-posterior test.
+
+### Added (carried from the pre-0.2.1 unreleased queue)
 
 - **Incremental HMC session API**: `HmcSession` exposes the HMC kernel one
   transition at a time (`step`, `step_recorded` with full leapfrog

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fugue-ppl"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cargo-llvm-cov",
  "clap 4.5.45",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["docs"]
 
 [package]
 name = "fugue-ppl"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 # Finding FG-51: the README previously claimed "1.70+" with nothing pinning or
 # verifying it. Verified empirically against real toolchains (not just

--- a/src/core/address.rs
+++ b/src/core/address.rs
@@ -103,6 +103,40 @@ impl Address {
     pub fn as_str(&self) -> &str {
         &self.repr
     }
+
+    /// True iff this address is `prefix` itself or a descendant of it under the
+    /// address path grammar — i.e. `prefix` followed by a segment separator
+    /// (`#` from [`addr!`](crate::addr), `::` from
+    /// [`scoped_addr!`](crate::scoped_addr), or a caller-chosen `/`). Unlike a
+    /// raw [`str::starts_with`], this does **not** treat `"gene"` as a prefix of
+    /// `"generation"`.
+    ///
+    /// A `prefix` that already ends in a separator character (`#`, `/`, or `:`)
+    /// is matched by plain `starts_with`; callers using a bespoke separator
+    /// should pass the prefix *including* the trailing separator (e.g.
+    /// `"first/"`).
+    ///
+    /// ```rust
+    /// use fugue::*;
+    ///
+    /// assert!(addr!("gene", 3).has_prefix("gene"));
+    /// assert!(Address::new("node/0/1").has_prefix("node/0"));
+    /// assert!(Address::new("scope::x").has_prefix("scope"));
+    /// assert!(!Address::new("generation").has_prefix("gene"));
+    /// ```
+    pub fn has_prefix(&self, prefix: &str) -> bool {
+        let s = self.as_str();
+        let Some(rest) = s.strip_prefix(prefix) else {
+            return false;
+        };
+        if rest.is_empty() {
+            return true;
+        }
+        if matches!(prefix.chars().last(), Some('#' | '/' | ':')) {
+            return true;
+        }
+        rest.starts_with('#') || rest.starts_with('/') || rest.starts_with("::")
+    }
 }
 
 impl Display for Address {

--- a/src/inference/mh.rs
+++ b/src/inference/mh.rs
@@ -114,7 +114,7 @@ use crate::core::distribution::Distribution;
 use crate::core::model::Model;
 use crate::inference::mcmc_utils::DiminishingAdaptation;
 use crate::runtime::handler::{run, Handler};
-use crate::runtime::interpreters::{PriorHandler, ScoreGivenTrace};
+use crate::runtime::interpreters::{score_given_trace_reconciled, PriorHandler, ScoreGivenTrace};
 use crate::runtime::trace::{Choice, ChoiceValue, Trace};
 use rand::{Rng, RngCore};
 use std::collections::HashMap;
@@ -634,7 +634,7 @@ impl<'a, R: RngCore> Handler for SingleSiteProposalHandler<'a, R> {
 /// cached site list even when the site count is unchanged (e.g. a branch that
 /// swaps one address for another).
 #[allow(clippy::type_complexity)]
-fn propose_and_score<A, F, R>(
+pub(crate) fn propose_and_score<A, F, R>(
     rng: &mut R,
     model_fn: &F,
     current: &Trace,
@@ -862,6 +862,105 @@ pub fn adaptive_single_site_mh<A, R: Rng>(
     }
 }
 
+/// One block-regeneration Metropolis–Hastings transition.
+///
+/// Deletes the choices at every address in `block` from `current`, replays the
+/// model to fill them (fresh draws from the prior, via
+/// [`score_given_trace_reconciled`]), and accepts or rejects with the
+/// prior-cancelling acceptance ratio below. This generalizes single-site MH
+/// from one target address to an arbitrary address set S — the "selective
+/// resampling" primitive: proposal = regenerate the sub-trace at S from the
+/// prior conditioned on the untouched coordinates.
+///
+/// `beta` tempers the likelihood (`π_β(θ) ∝ p(θ)·p(y|θ)^β`; pass `1.0` for an
+/// untempered posterior move), which makes the move directly usable as an SMC
+/// block-rejuvenation kernel. Addresses in `block` absent from `current` are
+/// ignored; present-but-mismatched-type entries are treated as fresh by the
+/// reconciler. The returned trace is freshly scored (FG-40/FG-48), so
+/// `total_log_weight()` is valid.
+///
+/// # Acceptance ratio
+///
+/// ```text
+/// log α = (log_prior′ − log_prior) + β·(loglik′ − loglik) + log q_rev − log q_fwd
+/// log q_fwd = Σ_{a ∈ fresh}                    logp′(a)     (forward births from the prior)
+/// log q_rev = Σ_{a ∈ S present in current}     logp(a)
+///           + Σ_{a ∈ vanished}                 logp(a)      (death correction, FG-20/FG-21)
+/// ```
+///
+/// For a **fixed address structure** (`fresh = S`, `vanished = ∅`) the prior
+/// and proposal terms cancel exactly and this collapses to
+/// `log α = β·(loglik′ − loglik)` — the prior-cancellation property that makes
+/// block regeneration cheap to accept/reject.
+///
+/// Unlike the single-site kernels there is **no dimension-selection term**
+/// (`ln|sites(current)| − ln|sites(proposed)|`): that term corrects for picking
+/// the target uniformly among a state-dependent site set, whereas here the
+/// block S is fixed by the caller — the forward and reverse moves regenerate
+/// deterministic address sets whose proposal densities are fully accounted by
+/// the `log q` terms above.
+///
+/// If the reconciling replay reports an address conflict (the model visits the
+/// same address twice, FG-47), the move is treated as a rejection and the
+/// (re-scored) current state is returned.
+pub fn block_regeneration_mh<A, R: Rng>(
+    rng: &mut R,
+    model_fn: impl Fn() -> Model<A>,
+    current: &Trace,
+    block: &[Address],
+    beta: f64,
+) -> (A, Trace) {
+    // Score the current state once; also the state returned on rejection (FG-40).
+    let (a_cur, cur_scored) = run(
+        ScoreGivenTrace {
+            base: current.clone(),
+            trace: Trace::default(),
+        },
+        model_fn(),
+    );
+
+    // Delete the block, then replay: removed addresses the model re-visits are
+    // drawn fresh from their prior (reported in `fresh_addresses`); addresses
+    // the model no longer visits are `vanished_addresses`.
+    let mut base = current.clone();
+    for a in block {
+        base.choices.remove(a);
+    }
+    let (a_prop, prop, report) = match score_given_trace_reconciled(base, rng, model_fn()) {
+        Ok(t) => t,
+        Err(_) => return (a_cur, cur_scored), // reject on address conflict
+    };
+
+    let log_q_fwd: f64 = report
+        .fresh_addresses
+        .iter()
+        .filter_map(|a| prop.choices.get(a).map(|c| c.logp))
+        .sum();
+    // Block ∩ vanished = ∅ (vanished is computed against the block-deleted
+    // base), so the two reverse-birth sums never double-count a site.
+    let log_q_rev: f64 = block
+        .iter()
+        .filter_map(|a| current.choices.get(a).map(|c| c.logp))
+        .sum::<f64>()
+        + report
+            .vanished_addresses
+            .iter()
+            .filter_map(|a| current.choices.get(a).map(|c| c.logp))
+            .sum::<f64>();
+
+    let loglik = |t: &Trace| t.log_likelihood + t.log_factors;
+    let log_alpha = (prop.log_prior - cur_scored.log_prior)
+        + beta * (loglik(&prop) - loglik(&cur_scored))
+        + log_q_rev
+        - log_q_fwd;
+
+    if log_alpha >= 0.0 || rng.gen::<f64>() < log_alpha.exp() {
+        (a_prop, prop)
+    } else {
+        (a_cur, cur_scored)
+    }
+}
+
 /// Run an adaptive MCMC chain with automatic proposal tuning.
 ///
 /// This is the main entry point for running Metropolis-Hastings MCMC on a
@@ -1033,6 +1132,230 @@ mod tests {
     use crate::runtime::handler::run;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
+
+    /// EA-as-PPL F2: block regeneration over the single latent site of a
+    /// Beta-Bernoulli model is an independence sampler from the prior and must
+    /// reproduce the closed-form Beta posterior.
+    #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)] // &model_fn is reused across loop iterations
+    fn test_block_regen_beta_bernoulli() {
+        use crate::inference::validation::{
+            test_conjugate_beta_bernoulli_model, ConjugateBetaBernoulliConfig,
+        };
+        use crate::runtime::interpreters::PriorHandler;
+
+        let observations = vec![
+            true, true, false, true, false, true, true, false, true, true,
+        ];
+        let obs_for_model = observations.clone();
+        let model_fn = move || {
+            let obs = obs_for_model.clone();
+            sample(addr!("theta"), Beta::new(2.0, 2.0).unwrap()).and_then(move |theta| {
+                let mut m = crate::core::model::pure(());
+                for (i, &o) in obs.iter().enumerate() {
+                    m = m.and_then(move |_| {
+                        observe(
+                            addr!("obs", i),
+                            Bernoulli::new(theta.clamp(1e-9, 1.0 - 1e-9)).unwrap(),
+                            o,
+                        )
+                    });
+                }
+                m.map(move |_| theta)
+            })
+        };
+
+        let mcmc_fn = |rng: &mut StdRng, n_samples: usize, n_warmup: usize| {
+            let (_, mut current) = run(
+                PriorHandler {
+                    rng,
+                    trace: Trace::default(),
+                },
+                model_fn(),
+            );
+            let block = [addr!("theta")];
+            let mut samples = Vec::with_capacity(n_samples);
+            for it in 0..(n_samples + n_warmup) {
+                let (v, t) = block_regeneration_mh(rng, &model_fn, &current, &block, 1.0);
+                current = t;
+                if it >= n_warmup {
+                    samples.push((v, current.clone()));
+                }
+            }
+            samples
+        };
+
+        let mut rng = StdRng::seed_from_u64(34);
+        let result = test_conjugate_beta_bernoulli_model(
+            &mut rng,
+            mcmc_fn,
+            ConjugateBetaBernoulliConfig {
+                prior_alpha: 2.0,
+                prior_beta: 2.0,
+                observations,
+                n_samples: 8000,
+                n_warmup: 500,
+            },
+        );
+        assert!(
+            result.is_valid(),
+            "block-regeneration chain failed conjugate Beta-Bernoulli validation"
+        );
+    }
+
+    /// EA-as-PPL F2: on a fixed-structure product-Normal model, a single block
+    /// move over ALL sites targets the same (analytic) posterior as the
+    /// single-site kernel — the prior-cancellation collapse `log α = β·Δloglik`.
+    #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)] // &model_fn is reused across loop iterations
+    fn test_block_vs_sequential_single_site() {
+        use crate::runtime::interpreters::PriorHandler;
+
+        // Two independent Normal(0,1) sites, each observed with sd 1:
+        // posterior per site is Normal(y/2, 1/2).
+        let (y0, y1) = (1.0, -0.5);
+        let model_fn = move || {
+            sample(addr!("x", 0), Normal::new(0.0, 1.0).unwrap()).and_then(move |x0| {
+                sample(addr!("x", 1), Normal::new(0.0, 1.0).unwrap()).and_then(move |x1| {
+                    observe(addr!("y", 0), Normal::new(x0, 1.0).unwrap(), y0).and_then(move |_| {
+                        observe(addr!("y", 1), Normal::new(x1, 1.0).unwrap(), y1)
+                            .map(move |_| (x0, x1))
+                    })
+                })
+            })
+        };
+
+        let mut rng = StdRng::seed_from_u64(44);
+        let (_, mut current) = run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            model_fn(),
+        );
+        let block = [addr!("x", 0), addr!("x", 1)];
+        let mut xs0 = Vec::new();
+        let mut xs1 = Vec::new();
+        for it in 0..6000 {
+            let (_, t) = block_regeneration_mh(&mut rng, &model_fn, &current, &block, 1.0);
+            current = t;
+            if it >= 500 {
+                xs0.push(current.get_f64(&addr!("x", 0)).unwrap());
+                xs1.push(current.get_f64(&addr!("x", 1)).unwrap());
+            }
+        }
+        for (xs, y) in [(&xs0, y0), (&xs1, y1)] {
+            let mean: f64 = xs.iter().sum::<f64>() / xs.len() as f64;
+            let var: f64 = xs.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / xs.len() as f64;
+            assert!(
+                (mean - y / 2.0).abs() < 0.08,
+                "posterior mean {} vs analytic {}",
+                mean,
+                y / 2.0
+            );
+            assert!((var - 0.5).abs() < 0.08, "posterior var {} vs 0.5", var);
+        }
+    }
+
+    /// EA-as-PPL F2: trans-dimensional block regeneration. A Bernoulli switch
+    /// gates an extra Normal site; the block = {switch, extra} move opens and
+    /// closes the branch, and the fresh/vanished bookkeeping must reproduce the
+    /// analytic posterior over the switch.
+    #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)] // &model_fn is reused across loop iterations
+    fn test_block_regen_transdimensional() {
+        use crate::runtime::interpreters::PriorHandler;
+
+        let y = 1.5;
+        let p_switch = 0.3;
+        let model_fn = move || {
+            sample(addr!("b"), Bernoulli::new(p_switch).unwrap()).and_then(move |b| {
+                if b {
+                    sample(addr!("x"), Normal::new(0.0, 1.0).unwrap()).and_then(move |x| {
+                        observe(addr!("y"), Normal::new(x, 1.0).unwrap(), y).map(move |_| b)
+                    })
+                } else {
+                    observe(addr!("y"), Normal::new(0.0, 2.0).unwrap(), y).map(move |_| b)
+                }
+            })
+        };
+
+        // Analytic: p(y|b=1) = N(y; 0, sqrt(2)) (x marginalized), p(y|b=0) = N(y; 0, 2).
+        let lik1 = normal_logpdf(y, 0.0, std::f64::consts::SQRT_2).exp();
+        let lik0 = normal_logpdf(y, 0.0, 2.0).exp();
+        let post_b1 = p_switch * lik1 / (p_switch * lik1 + (1.0 - p_switch) * lik0);
+
+        let mut rng = StdRng::seed_from_u64(55);
+        let (_, mut current) = run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            model_fn(),
+        );
+        let block = [addr!("b"), addr!("x")];
+        let mut b_sum = 0.0;
+        let mut n = 0.0;
+        for it in 0..20000 {
+            let (_, t) = block_regeneration_mh(&mut rng, &model_fn, &current, &block, 1.0);
+            current = t;
+            if it >= 1000 {
+                b_sum += if current.get_bool(&addr!("b")).unwrap() {
+                    1.0
+                } else {
+                    0.0
+                };
+                n += 1.0;
+            }
+        }
+        let b_mean = b_sum / n;
+        assert!(
+            (b_mean - post_b1).abs() < 0.03,
+            "P(b=1) estimate {} vs analytic {}",
+            b_mean,
+            post_b1
+        );
+    }
+
+    /// EA-as-PPL F2 (FG-48 style): every state the block-regeneration chain
+    /// returns carries accumulators equal to a fresh from-scratch re-score.
+    #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)] // &model_fn is reused across loop iterations
+    fn test_block_regen_fresh_rescore_equality() {
+        use crate::runtime::interpreters::PriorHandler;
+
+        let model_fn = || {
+            sample(addr!("a"), Normal::new(0.0, 1.0).unwrap()).and_then(|a| {
+                sample(addr!("b"), Normal::new(a, 1.0).unwrap()).and_then(move |b| {
+                    observe(addr!("y"), Normal::new(a + b, 0.5).unwrap(), 0.7).map(move |_| (a, b))
+                })
+            })
+        };
+        let mut rng = StdRng::seed_from_u64(66);
+        let (_, mut current) = run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            model_fn(),
+        );
+        let block = [addr!("a")];
+        for _ in 0..50 {
+            let (_, t) = block_regeneration_mh(&mut rng, &model_fn, &current, &block, 1.0);
+            let (_, rescored) = run(
+                ScoreGivenTrace {
+                    base: t.clone(),
+                    trace: Trace::default(),
+                },
+                model_fn(),
+            );
+            assert!(
+                (t.total_log_weight() - rescored.total_log_weight()).abs() < 1e-12,
+                "returned trace's accumulators diverge from a fresh re-score"
+            );
+            current = t;
+        }
+    }
 
     #[test]
     fn gaussian_walk_proposal_produces_variation() {

--- a/src/inference/smc.rs
+++ b/src/inference/smc.rs
@@ -56,14 +56,15 @@
 //! assert!(ess > 0.0);
 //! ```
 use crate::core::address::Address;
-use crate::core::distribution::{Distribution, Normal};
 use crate::core::model::Model;
 use crate::core::numerical::log_sum_exp;
 use crate::inference::mcmc_utils::DiminishingAdaptation;
+use crate::inference::mh::{propose_and_score, SiteProposal};
 use crate::runtime::handler::run;
 use crate::runtime::interpreters::{PriorHandler, ScoreGivenTrace};
-use crate::runtime::trace::{ChoiceValue, Trace};
+use crate::runtime::trace::Trace;
 use rand::Rng;
+use std::collections::HashMap;
 
 /// A weighted particle in the SMC population.
 ///
@@ -372,6 +373,187 @@ impl std::ops::Deref for SMCResult {
     }
 }
 
+/// A population-coupled MCMC move applied to the whole particle slice between
+/// SMC tempering steps.
+///
+/// Unlike per-particle rejuvenation ([`rejuvenate_particles`]), a population
+/// kernel may *couple* particles — e.g. a crossover move that swaps a block of
+/// choices between two parent traces. It is invoked by
+/// [`adaptive_smc_with_kernel`] immediately after resampling and per-particle
+/// rejuvenation, on a uniform-weight population that is (approximately)
+/// distributed according to the current tempered target π_β.
+///
+/// # Invariance contract (MUST hold, or SMC estimates are biased)
+///
+/// For a single model execution, `π_β(θ) ∝ p(θ) · p(y|θ)^β`. A kernel that
+/// couples the pair (i, j) MUST leave the **product target**
+/// `π_β(θ_i) · π_β(θ_j)` invariant (and analogously for any k-tuple it
+/// couples). Concretely the implementation MUST:
+///
+/// * **(W)** never write `particle.weight` or `particle.log_weight` — after
+///   resampling the weights are uniform and an invariant move keeps them
+///   uniform (findings FG-03 / FG-13). Reweighting here re-introduces the
+///   prior-squaring bias FG-03 fixed.
+/// * **(T)** mutate only `particle.trace`, and only to a value obtained by a
+///   Metropolis accept/reject whose target is the product of the coupled
+///   particles' tempered densities.
+/// * **(S)** re-score every trace it writes under `model_fn` (via
+///   [`ScoreGivenTrace`] or
+///   [`score_given_trace_reconciled`](crate::runtime::interpreters::score_given_trace_reconciled))
+///   so the three log accumulators are valid — direct choice surgery does NOT
+///   update them (see [`Trace::insert_choice`]).
+/// * **(E)** not read or mutate the SMC log-evidence accumulator (it has no
+///   access to it) — an invariant move contributes no incremental weight
+///   (FG-58).
+///
+/// # Correctness of the built-in crossover move
+///
+/// Between tempering steps the uniform-weight population is approximately
+/// i.i.d. from π_β, so a coupled pair (θ_i, θ_j) is distributed as
+/// `π_β ⊗ π_β`. [`CrossoverKernel`] draws an address mask S from a
+/// value-independent, pair-symmetric distribution and deterministically swaps
+/// the values on S. This map is an **involution** (swapping S back recovers
+/// the parents) with identical forward/reverse mask distributions, so
+/// `q(child|parent) = q(parent|child)` and the Hastings correction is 1. The
+/// Metropolis acceptance
+/// `α = min(1, [π_β(θ_i')·π_β(θ_j')] / [π_β(θ_i)·π_β(θ_j)])` is therefore a
+/// valid Metropolis move on `π_β ⊗ π_β`, hence product-invariant; applied to a
+/// π_β population it preserves each particle's marginal and keeps the uniform
+/// weights correct (W). Being invariant it injects zero incremental weight, so
+/// the log-evidence accumulator is untouched (E). The re-score (S) makes
+/// off-support swaps (`guard` / `factor(-∞)`) reject via a `-∞` density —
+/// support-respecting truncation.
+///
+/// The kernel is object-safe: `rng` is `&mut dyn RngCore` (rand's blanket
+/// `impl<R: RngCore + ?Sized> Rng for R` supplies the sampling methods), and
+/// the model constructor is passed as `&dyn Fn`.
+pub trait PopulationKernel<A> {
+    /// Apply one population sweep in place. `beta` is the current tempering
+    /// exponent; `model_fn` reconstructs the single-execution model whose
+    /// tempered density defines the (product) target.
+    fn sweep(
+        &mut self,
+        rng: &mut dyn rand::RngCore,
+        particles: &mut [Particle],
+        model_fn: &dyn Fn() -> Model<A>,
+        beta: f64,
+    );
+}
+
+/// The identity population kernel: does nothing. [`adaptive_smc`] is defined
+/// as `adaptive_smc_with_kernel(.., &mut NoKernel)`.
+pub struct NoKernel;
+
+impl<A> PopulationKernel<A> for NoKernel {
+    fn sweep(
+        &mut self,
+        _: &mut dyn rand::RngCore,
+        _: &mut [Particle],
+        _: &dyn Fn() -> Model<A>,
+        _: f64,
+    ) {
+    }
+}
+
+/// A population crossover kernel: repeatedly picks two distinct particles at
+/// random, proposes a child pair by swapping the block of choices at the
+/// addresses chosen by `mask`, and accepts the swap with the product-target
+/// Metropolis ratio (see the correctness argument on [`PopulationKernel`]).
+///
+/// # v1 scope: fixed-structure models
+///
+/// The swap is exact for models whose address set is identical across
+/// executions (bit-string / permutation / real-vector genomes and other
+/// fixed-structure models): the swap is dimension-preserving and the
+/// [`ScoreGivenTrace`] re-score is exact. For variable-dimension models a
+/// swapped block can leave a partner with an incomplete assignment; such
+/// crossovers need a custom kernel built on
+/// [`score_given_trace_reconciled`](crate::runtime::interpreters::score_given_trace_reconciled)
+/// carrying the RJMCMC dimension bookkeeping.
+pub struct CrossoverKernel {
+    /// Number of (pair, swap) proposals per sweep.
+    pub n_pairs: usize,
+    /// Chooses the address set S to swap. Given the two parent traces it
+    /// returns the addresses whose values are exchanged between the pair. MUST
+    /// be value-independent (depend only on the address structure) and
+    /// symmetric in its two trace arguments for the move to be a symmetric
+    /// involution (Hastings ratio 1).
+    #[allow(clippy::type_complexity)]
+    pub mask: Box<dyn Fn(&Trace, &Trace, &mut dyn rand::RngCore) -> Vec<Address>>,
+}
+
+/// Build two children by exchanging the choices at `swap` between `a` and `b`.
+/// Pure choice surgery: the children's accumulators are NOT valid until
+/// re-scored (contract S of [`PopulationKernel`]).
+fn swap_block(a: &Trace, b: &Trace, swap: &[Address]) -> (Trace, Trace) {
+    let mut ca = a.clone();
+    let mut cb = b.clone();
+    for addr in swap {
+        let from_a = ca.choices.remove(addr);
+        let from_b = cb.choices.remove(addr);
+        if let Some(c) = from_b {
+            ca.choices.insert(addr.clone(), c);
+        }
+        if let Some(c) = from_a {
+            cb.choices.insert(addr.clone(), c);
+        }
+    }
+    (ca, cb)
+}
+
+impl<A> PopulationKernel<A> for CrossoverKernel {
+    fn sweep(
+        &mut self,
+        rng: &mut dyn rand::RngCore,
+        particles: &mut [Particle],
+        model_fn: &dyn Fn() -> Model<A>,
+        beta: f64,
+    ) {
+        let n = particles.len();
+        if n < 2 {
+            return;
+        }
+        for _ in 0..self.n_pairs {
+            let i = rng.gen_range(0..n);
+            let mut j = rng.gen_range(0..n - 1);
+            if j >= i {
+                j += 1; // distinct partner
+            }
+            let s = (self.mask)(&particles[i].trace, &particles[j].trace, rng);
+            if s.is_empty() {
+                continue;
+            }
+
+            // Build child traces by choice surgery, then RE-SCORE (contract S).
+            let (ti, tj) = swap_block(&particles[i].trace, &particles[j].trace, &s);
+            let (_ai, ci) = run(
+                ScoreGivenTrace {
+                    base: ti,
+                    trace: Trace::default(),
+                },
+                model_fn(),
+            );
+            let (_aj, cj) = run(
+                ScoreGivenTrace {
+                    base: tj,
+                    trace: Trace::default(),
+                },
+                model_fn(),
+            );
+
+            // Tempered log-density of a single execution:
+            //   log π_β(θ) = log_prior + β·(log_likelihood + log_factors).
+            let logd = |t: &Trace| t.log_prior + beta * (t.log_likelihood + t.log_factors);
+            let log_alpha =
+                (logd(&ci) + logd(&cj)) - (logd(&particles[i].trace) + logd(&particles[j].trace));
+            if log_alpha >= 0.0 || rng.gen::<f64>() < log_alpha.exp() {
+                particles[i].trace = ci; // (T): only traces move;
+                particles[j].trace = cj; // (W): weights untouched.
+            }
+        }
+    }
+}
+
 /// The log incremental target factor of a particle: log p(y | θ) = log_likelihood + log_factors.
 ///
 /// Under likelihood tempering the sequence of targets is
@@ -458,6 +640,34 @@ pub fn adaptive_smc<A, R: Rng>(
     model_fn: impl Fn() -> Model<A>,
     config: SMCConfig,
 ) -> SMCResult {
+    adaptive_smc_with_kernel(rng, num_particles, model_fn, config, &mut NoKernel)
+}
+
+/// Likelihood-tempered SMC with a population-coupled kernel applied between
+/// tempering steps.
+///
+/// Identical to [`adaptive_smc`] except that after each intermediate step's
+/// resample + per-particle rejuvenation (and before the likelihood refresh),
+/// `kernel.sweep(..)` is invoked on the whole particle slice at the current β.
+/// This is the hook for population-coupled MCMC moves — e.g. crossover between
+/// particle pairs ([`CrossoverKernel`]) — which per-particle rejuvenation
+/// cannot express. With [`NoKernel`] this is exactly [`adaptive_smc`].
+///
+/// The kernel runs only at **intermediate** tempering steps: the terminal
+/// β = 1 step returns the weighted particles without resampling or moves
+/// (FG-43), so the kernel never touches the returned weighted population. See
+/// [`PopulationKernel`] for the invariance contract the kernel must satisfy.
+pub fn adaptive_smc_with_kernel<A, R, K>(
+    rng: &mut R,
+    num_particles: usize,
+    model_fn: impl Fn() -> Model<A>,
+    config: SMCConfig,
+    kernel: &mut K,
+) -> SMCResult
+where
+    R: Rng,
+    K: PopulationKernel<A>,
+{
     let n = num_particles;
     if n == 0 {
         return SMCResult {
@@ -552,6 +762,15 @@ pub fn adaptive_smc<A, R: Rng>(
                         );
                     }
                 }
+                // Population-coupled kernel sweep (π_β⊗…⊗π_β-invariant, weights
+                // untouched — see the PopulationKernel contract). Runs before the
+                // likelihood refresh below so moved traces are picked up.
+                kernel.sweep(
+                    rng as &mut dyn rand::RngCore,
+                    &mut particles,
+                    &model_fn,
+                    beta,
+                );
                 logliks = particles
                     .iter()
                     .map(|p| particle_log_likelihood(&p.trace))
@@ -623,11 +842,27 @@ fn next_beta(beta: f64, log_w: &[f64], logliks: &[f64], target_ess: f64) -> f64 
 
 /// A single π_β-invariant single-site Metropolis-Hastings rejuvenation move.
 ///
-/// Perturbs one randomly chosen continuous (f64) site with a symmetric Gaussian
-/// random walk and accepts against the tempered target π_β(θ) ∝ p(θ)·p(y|θ)^β.
-/// Because the proposal is symmetric there is no Hastings correction. The move is
-/// invariant for π_β, so applying it to a resampled (uniform-weight) population
-/// leaves the weights uniform.
+/// Picks the target uniformly over **all** of the trace's sites and dispatches
+/// the proposal by value type through the same typed machinery as
+/// [`adaptive_single_site_mh`](crate::inference::mh::adaptive_single_site_mh):
+/// Gaussian/log-space/reflected walks for `F64`, a deterministic flip for
+/// `Bool`, a reflected discrete walk for `U64`, prior-resample for `Usize`
+/// categoricals, and an integer walk for `I64`. (The previous implementation
+/// collected only `F64` sites, so populations of pure Bool/Usize/U64 traces —
+/// e.g. bit-string or permutation genomes — never moved during rejuvenation.)
+///
+/// Acceptance is the tempered trans-dimensional ratio
+///
+/// ```text
+/// log α = Δlog_prior + β·Δloglik + (log q_rev − log q_fwd) + dim_term
+/// ```
+///
+/// against π_β(θ) ∝ p(θ)·p(y|θ)^β. Births/deaths of prior-proposed structure
+/// carry their RJMCMC corrections in `log q_fwd`/`log q_rev` (the prior is
+/// untempered in π_β, so the usual prior-cancellation still holds), and
+/// `dim_term = ln|sites(current)| − ln|sites(proposed)|` (FG-20/FG-21; 0 for
+/// fixed-structure models). The move is invariant for π_β, so applying it to a
+/// resampled (uniform-weight) population leaves the weights uniform.
 fn tempered_single_site_mh<A, R: Rng>(
     rng: &mut R,
     model_fn: &impl Fn() -> Model<A>,
@@ -635,30 +870,29 @@ fn tempered_single_site_mh<A, R: Rng>(
     beta: f64,
     adaptation: &mut DiminishingAdaptation,
 ) -> Trace {
-    // Collect continuous sites eligible for a Gaussian random-walk perturbation.
-    let f64_sites: Vec<Address> = current
-        .choices
-        .iter()
-        .filter(|(_, c)| matches!(c.value, ChoiceValue::F64(_)))
-        .map(|(a, _)| a.clone())
-        .collect();
-    if f64_sites.is_empty() {
+    if current.choices.is_empty() {
         // Nothing to move; doing nothing is trivially π_β-invariant.
         return current.clone();
     }
 
-    let site = f64_sites[rng.gen_range(0..f64_sites.len())].clone();
-    let scale = adaptation.get_scale(&site);
-    let cur_val = current.choices[&site].value.as_f64().unwrap();
+    let sites: Vec<Address> = current.choices.keys().cloned().collect();
+    let target = sites[rng.gen_range(0..sites.len())].clone();
+    let scale = adaptation.get_scale(&target);
 
-    // Symmetric Gaussian random walk on the selected coordinate.
-    let z = Normal::new(0.0, 1.0).unwrap().sample(rng);
-    let prop_val = cur_val + scale * z;
+    let overrides: HashMap<Address, SiteProposal> = HashMap::new();
+    let mut kind_cache: HashMap<Address, SiteProposal> = HashMap::new();
+    let (_a_prop, prop_trace, _prop_lw, lqf, lqr, _structure_changed) = propose_and_score(
+        rng,
+        model_fn,
+        current,
+        &target,
+        scale,
+        &overrides,
+        &mut kind_cache,
+    );
 
-    let mut proposed = current.clone();
-    proposed.choices.get_mut(&site).unwrap().value = ChoiceValue::F64(prop_val);
-
-    // Score current and proposed traces under the model.
+    // Score the current state (also refreshes accumulators for the trace we
+    // return on rejection, FG-40).
     let (_, cur_scored) = run(
         ScoreGivenTrace {
             base: current.clone(),
@@ -666,22 +900,17 @@ fn tempered_single_site_mh<A, R: Rng>(
         },
         model_fn(),
     );
-    let (_, prop_scored) = run(
-        ScoreGivenTrace {
-            base: proposed,
-            trace: Trace::default(),
-        },
-        model_fn(),
-    );
 
-    // Tempered acceptance: Δlog_prior + β·Δloglik (symmetric proposal ⇒ no Hastings).
-    let log_alpha = (prop_scored.log_prior - cur_scored.log_prior)
-        + beta * (particle_log_likelihood(&prop_scored) - particle_log_likelihood(&cur_scored));
+    let dim_term = (sites.len() as f64).ln() - (prop_trace.choices.len() as f64).ln();
+    let log_alpha = (prop_trace.log_prior - cur_scored.log_prior)
+        + beta * (particle_log_likelihood(&prop_trace) - particle_log_likelihood(&cur_scored))
+        + (lqr - lqf)
+        + dim_term;
     let accept = log_alpha >= 0.0 || rng.gen::<f64>() < log_alpha.exp();
-    adaptation.update(&site, accept);
+    adaptation.update(&target, accept);
 
     if accept {
-        prop_scored
+        prop_trace
     } else {
         cur_scored
     }
@@ -789,6 +1018,75 @@ pub fn smc_prior_particles<A, R: Rng>(
     particles
 }
 
+/// Recover the model return value (e.g. a decoded genome) from a particle's
+/// trace by replaying the model against it.
+///
+/// Uses [`ScoreGivenTrace`], which requires the trace to be a complete
+/// assignment for `model_fn` — always true for particles produced by
+/// [`adaptive_smc`] / [`adaptive_smc_with_kernel`] with the same model. Costs
+/// one model execution. `Particle` deliberately does not cache the return
+/// value: storing it would force `A: Clone` through every resample/rejuvenation
+/// path and break the move-not-clone particle construction (FG-59); decode is
+/// deterministic given the trace, so nothing is lost.
+///
+/// For traces of uncertain provenance (where a site may be missing or
+/// type-mismatched), use [`try_decode_particle`] instead — `ScoreGivenTrace`
+/// panics on an incomplete assignment.
+pub fn decode_particle<A>(particle: &Particle, model_fn: impl Fn() -> Model<A>) -> A {
+    let (a, _) = run(
+        ScoreGivenTrace {
+            base: particle.trace.clone(),
+            trace: Trace::default(),
+        },
+        model_fn(),
+    );
+    a
+}
+
+/// Fallible sibling of [`decode_particle`] for traces of uncertain provenance,
+/// backed by [`SafeScoreGivenTrace`](crate::runtime::interpreters::SafeScoreGivenTrace):
+/// a missing or type-mismatched site returns `Err` instead of panicking.
+///
+/// The failure signal is the safe scorer's `-∞` `log_prior` sentinel: a trace
+/// that IS a complete, in-support assignment for `model_fn` always scores a
+/// finite log-prior, so a non-finite one means the trace does not decode under
+/// this model.
+pub fn try_decode_particle<A>(
+    particle: &Particle,
+    model_fn: impl Fn() -> Model<A>,
+) -> crate::error::FugueResult<A> {
+    let (a, scored) = run(
+        crate::runtime::interpreters::SafeScoreGivenTrace {
+            base: particle.trace.clone(),
+            trace: Trace::default(),
+            warn_on_error: false,
+        },
+        model_fn(),
+    );
+    if scored.log_prior.is_finite() {
+        Ok(a)
+    } else {
+        Err(crate::error::FugueError::trace_error(
+            "try_decode_particle",
+            None,
+            "particle trace is not a complete in-support assignment for this model",
+            crate::error::ErrorCode::TraceAddressNotFound,
+        ))
+    }
+}
+
+/// Decode a whole population, pairing each decoded value with its normalized
+/// weight — the shape posterior readouts (weighted mean / argmax) consume.
+pub fn decode_particles<A>(
+    particles: &[Particle],
+    model_fn: impl Fn() -> Model<A>,
+) -> Vec<(A, f64)> {
+    particles
+        .iter()
+        .map(|p| (decode_particle(p, &model_fn), p.weight))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -864,6 +1162,367 @@ mod tests {
         // Fallback to uniform
         assert!((particles[0].weight - 0.5).abs() < 1e-12);
         assert!((particles[1].weight - 0.5).abs() < 1e-12);
+    }
+
+    /// Regression (EA-as-PPL F1): rejuvenation must move non-F64 sites. The
+    /// previous kernel collected only `ChoiceValue::F64` sites and returned
+    /// `current.clone()` otherwise, so a population of pure-Bool traces (a
+    /// bit-string genome) was frozen forever.
+    #[test]
+    fn test_smc_rejuvenation_moves_bitstring() {
+        let n_bits = 4usize;
+        let model_fn = move || {
+            let bits: Vec<Model<bool>> = (0..n_bits)
+                .map(|i| sample(addr!("bit", i), Bernoulli::new(0.5).unwrap()))
+                .collect();
+            crate::core::model::sequence_vec(bits).bind(|bs| {
+                let k = bs.iter().filter(|&&b| b).count() as f64;
+                crate::core::model::factor(k).map(move |_| bs)
+            })
+        };
+
+        // Direct movement check: a population cloned from ONE prior draw must
+        // diversify under rejuvenation (before the fix: bit-identical forever).
+        let mut rng = StdRng::seed_from_u64(11);
+        let seed_particles = smc_prior_particles(&mut rng, 1, model_fn);
+        let mut particles: Vec<Particle> = (0..20).map(|_| seed_particles[0].clone()).collect();
+        rejuvenate_particles(&mut rng, &mut particles, model_fn, 1.0, 5);
+        let moved = particles.iter().any(|p| {
+            (0..n_bits).any(|i| {
+                p.trace.get_bool(&addr!("bit", i))
+                    != seed_particles[0].trace.get_bool(&addr!("bit", i))
+            })
+        });
+        assert!(
+            moved,
+            "Bool-only population did not move under rejuvenation"
+        );
+
+        // Analytic marginal check: per-bit posterior p(1) = e/(1+e) ≈ 0.7311.
+        let config = SMCConfig {
+            resampling_method: ResamplingMethod::Systematic,
+            ess_threshold: 0.5,
+            rejuvenation_steps: 2,
+        };
+        let result = adaptive_smc(&mut rng, 400, model_fn, config);
+        let p1 = std::f64::consts::E / (1.0 + std::f64::consts::E);
+        for i in 0..n_bits {
+            let mean: f64 = result
+                .iter()
+                .map(|p| {
+                    let b = p.trace.get_bool(&addr!("bit", i)).unwrap();
+                    p.weight * if b { 1.0 } else { 0.0 }
+                })
+                .sum();
+            assert!(
+                (mean - p1).abs() < 0.09,
+                "bit {} posterior mean {} vs analytic {}",
+                i,
+                mean,
+                p1
+            );
+        }
+    }
+
+    /// Helper: two independent Normal(0,1) sites each observed with sd 1.
+    /// Posterior per site: Normal(y_i/2, 1/2).
+    fn two_site_model(y0: f64, y1: f64) -> impl Fn() -> Model<(f64, f64)> + Clone {
+        move || {
+            sample(addr!("x", 0), Normal::new(0.0, 1.0).unwrap()).and_then(move |x0| {
+                sample(addr!("x", 1), Normal::new(0.0, 1.0).unwrap()).and_then(move |x1| {
+                    observe(addr!("y", 0), Normal::new(x0, 1.0).unwrap(), y0).and_then(move |_| {
+                        observe(addr!("y", 1), Normal::new(x1, 1.0).unwrap(), y1)
+                            .map(move |_| (x0, x1))
+                    })
+                })
+            })
+        }
+    }
+
+    /// A value-independent, pair-symmetric mask: each of the two sites is
+    /// included in the swap independently with probability 1/2.
+    #[allow(clippy::type_complexity)]
+    fn random_site_mask() -> Box<dyn Fn(&Trace, &Trace, &mut dyn rand::RngCore) -> Vec<Address>> {
+        Box::new(|a: &Trace, _b: &Trace, rng: &mut dyn rand::RngCore| {
+            a.choices
+                .keys()
+                .filter(|_| rng.gen::<bool>())
+                .cloned()
+                .collect()
+        })
+    }
+
+    /// EA-as-PPL F4: the crossover kernel is π⊗π-invariant — a population
+    /// initialized FROM the analytic posterior stays posterior-distributed
+    /// under repeated sweeps. (Crossover only exchanges values between
+    /// particles, so this — not prior-to-posterior transport — is the correct
+    /// invariance check.)
+    #[test]
+    fn test_crossover_product_invariance() {
+        let (y0, y1) = (1.0, -0.5);
+        let model_fn = two_site_model(y0, y1);
+        let mut rng = StdRng::seed_from_u64(77);
+
+        // Initialize each particle exactly from the product posterior.
+        let post0 = Normal::new(y0 / 2.0, (0.5f64).sqrt()).unwrap();
+        let post1 = Normal::new(y1 / 2.0, (0.5f64).sqrt()).unwrap();
+        let n = 300;
+        let mut particles: Vec<Particle> = (0..n)
+            .map(|_| {
+                let mut base = Trace::default();
+                base.insert_choice(
+                    addr!("x", 0),
+                    crate::runtime::trace::ChoiceValue::F64(post0.sample(&mut rng)),
+                    0.0,
+                );
+                base.insert_choice(
+                    addr!("x", 1),
+                    crate::runtime::trace::ChoiceValue::F64(post1.sample(&mut rng)),
+                    0.0,
+                );
+                let (_, scored) = run(
+                    ScoreGivenTrace {
+                        base,
+                        trace: Trace::default(),
+                    },
+                    model_fn(),
+                );
+                Particle {
+                    trace: scored,
+                    weight: 1.0 / n as f64,
+                    log_weight: -(n as f64).ln(),
+                }
+            })
+            .collect();
+
+        let mut kernel = CrossoverKernel {
+            n_pairs: 150,
+            mask: random_site_mask(),
+        };
+        for _ in 0..40 {
+            PopulationKernel::<(f64, f64)>::sweep(
+                &mut kernel,
+                &mut rng,
+                &mut particles,
+                &model_fn,
+                1.0,
+            );
+        }
+
+        for (i, target_mean) in [(0usize, y0 / 2.0), (1usize, y1 / 2.0)] {
+            let xs: Vec<f64> = particles
+                .iter()
+                .map(|p| p.trace.get_f64(&addr!("x", i)).unwrap())
+                .collect();
+            let mean: f64 = xs.iter().sum::<f64>() / xs.len() as f64;
+            let var: f64 = xs.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / xs.len() as f64;
+            assert!(
+                (mean - target_mean).abs() < 0.15,
+                "site {} marginal mean {} drifted from posterior {}",
+                i,
+                mean,
+                target_mean
+            );
+            assert!(
+                (var - 0.5).abs() < 0.15,
+                "site {} marginal var {} drifted from posterior 0.5",
+                i,
+                var
+            );
+        }
+    }
+
+    /// EA-as-PPL F4 contract (W): a sweep never touches particle weights.
+    #[test]
+    fn test_crossover_preserves_uniform_weights() {
+        let model_fn = two_site_model(1.0, -0.5);
+        let mut rng = StdRng::seed_from_u64(88);
+        let mut particles = smc_prior_particles(&mut rng, 30, &model_fn);
+        let before: Vec<(f64, f64)> = particles.iter().map(|p| (p.weight, p.log_weight)).collect();
+
+        let mut kernel = CrossoverKernel {
+            n_pairs: 60,
+            mask: random_site_mask(),
+        };
+        PopulationKernel::<(f64, f64)>::sweep(
+            &mut kernel,
+            &mut rng,
+            &mut particles,
+            &model_fn,
+            0.7,
+        );
+
+        let after: Vec<(f64, f64)> = particles.iter().map(|p| (p.weight, p.log_weight)).collect();
+        assert_eq!(before, after, "crossover sweep modified particle weights");
+    }
+
+    /// EA-as-PPL F4 contract (E) / FG-58: an invariant kernel must not shift
+    /// the log-evidence estimate. Both runs are compared to the analytic
+    /// marginal likelihood of the conjugate model.
+    #[test]
+    fn test_crossover_evidence_noncorruption() {
+        let (y0, y1) = (1.0, -0.5);
+        let model_fn = two_site_model(y0, y1);
+        // Analytic: y_i ~ N(0, sqrt(1² + 1²)) independently.
+        let marg = Normal::new(0.0, (2.0f64).sqrt()).unwrap();
+        let analytic = marg.log_prob(&y0) + marg.log_prob(&y1);
+
+        let config = || SMCConfig {
+            resampling_method: ResamplingMethod::Systematic,
+            ess_threshold: 0.7,
+            rejuvenation_steps: 2,
+        };
+        let mut rng = StdRng::seed_from_u64(99);
+        let plain = adaptive_smc(&mut rng, 600, &model_fn, config());
+        let mut kernel = CrossoverKernel {
+            n_pairs: 300,
+            mask: random_site_mask(),
+        };
+        let crossed = adaptive_smc_with_kernel(&mut rng, 600, &model_fn, config(), &mut kernel);
+
+        assert!(
+            (plain.log_evidence - analytic).abs() < 0.25,
+            "NoKernel evidence {} vs analytic {}",
+            plain.log_evidence,
+            analytic
+        );
+        assert!(
+            (crossed.log_evidence - analytic).abs() < 0.25,
+            "CrossoverKernel evidence {} vs analytic {}",
+            crossed.log_evidence,
+            analytic
+        );
+    }
+
+    /// EA-as-PPL F4: swaps that leave the target's support must be rejected.
+    /// The constraint couples the two sites (x0 + x1 ≤ 1), so a crossover swap
+    /// CAN violate it — the re-scored `-∞` density must reject the move.
+    #[test]
+    fn test_crossover_support_truncation() {
+        let model_fn = || {
+            sample(addr!("x", 0), Normal::new(0.0, 1.0).unwrap()).and_then(|x0| {
+                sample(addr!("x", 1), Normal::new(0.0, 1.0).unwrap()).and_then(move |x1| {
+                    crate::core::model::guard(x0 + x1 <= 1.0).map(move |_| (x0, x1))
+                })
+            })
+        };
+        let mut rng = StdRng::seed_from_u64(111);
+
+        // Build a valid population by rejection from the prior.
+        let n = 60;
+        let mut particles = Vec::with_capacity(n);
+        while particles.len() < n {
+            let (_, t) = run(
+                PriorHandler {
+                    rng: &mut rng,
+                    trace: Trace::default(),
+                },
+                model_fn(),
+            );
+            if t.total_log_weight().is_finite() {
+                particles.push(Particle {
+                    trace: t,
+                    weight: 1.0 / n as f64,
+                    log_weight: -(n as f64).ln(),
+                });
+            }
+        }
+
+        let mut kernel = CrossoverKernel {
+            n_pairs: 120,
+            // Swap only site 0 — guaranteed to threaten the joint constraint.
+            mask: Box::new(|_: &Trace, _: &Trace, _: &mut dyn rand::RngCore| vec![addr!("x", 0)]),
+        };
+        for _ in 0..30 {
+            PopulationKernel::<(f64, f64)>::sweep(
+                &mut kernel,
+                &mut rng,
+                &mut particles,
+                &model_fn,
+                1.0,
+            );
+            for p in &particles {
+                let x0 = p.trace.get_f64(&addr!("x", 0)).unwrap();
+                let x1 = p.trace.get_f64(&addr!("x", 1)).unwrap();
+                assert!(
+                    x0 + x1 <= 1.0 + 1e-12,
+                    "accepted crossover left the truncated support: {} + {} > 1",
+                    x0,
+                    x1
+                );
+            }
+        }
+    }
+
+    /// EA-as-PPL F5: decode returns exactly the value implied by the trace,
+    /// decoded weights sum to 1, and the fallible variant rejects a foreign
+    /// trace.
+    #[test]
+    fn test_decode_fidelity() {
+        let model_fn = || {
+            sample(addr!("mu"), Normal::new(0.0, 1.0).unwrap()).and_then(|mu| {
+                observe(addr!("y"), Normal::new(mu, 1.0).unwrap(), 0.5).map(move |_| mu)
+            })
+        };
+        let mut rng = StdRng::seed_from_u64(123);
+        let particles = smc_prior_particles(&mut rng, 20, model_fn);
+        for p in &particles {
+            let decoded = decode_particle(p, model_fn);
+            assert_eq!(decoded, p.trace.get_f64(&addr!("mu")).unwrap());
+            assert_eq!(try_decode_particle(p, model_fn).unwrap(), decoded);
+        }
+        let decoded = decode_particles(&particles, model_fn);
+        let total: f64 = decoded.iter().map(|(_, w)| w).sum();
+        assert!((total - 1.0).abs() < 1e-9);
+
+        // A trace missing the model's site must fail the fallible decode.
+        let foreign = Particle {
+            trace: Trace::default(),
+            weight: 1.0,
+            log_weight: 0.0,
+        };
+        assert!(try_decode_particle(&foreign, model_fn).is_err());
+    }
+
+    /// EA-as-PPL F5 + EV-16 end-to-end: the fugue-evo conjugate "fitness as
+    /// likelihood" target — prior N(0, 2²), factor −½(x−3)² — reproduced
+    /// through `adaptive_smc_with_kernel` + `decode_particles`: posterior mean
+    /// 2.4 ± 0.15, variance 0.8 ± 0.2. This is the readout path fugue-evo's
+    /// rebuilt EvolutionarySMC uses in place of cached genome/fitness fields.
+    #[test]
+    fn test_decode_weighted_mean() {
+        let model_fn = || {
+            sample(addr!("gene", 0), Normal::new(0.0, 2.0).unwrap()).and_then(|x| {
+                crate::core::model::factor(-0.5 * (x - 3.0) * (x - 3.0)).map(move |_| x)
+            })
+        };
+        let mut rng = StdRng::seed_from_u64(2024);
+        let config = SMCConfig {
+            resampling_method: ResamplingMethod::Systematic,
+            ess_threshold: 0.7,
+            rejuvenation_steps: 3,
+        };
+        let mut kernel = CrossoverKernel {
+            n_pairs: 200,
+            mask: Box::new(|_: &Trace, _: &Trace, _: &mut dyn rand::RngCore| {
+                vec![addr!("gene", 0)]
+            }),
+        };
+        let result = adaptive_smc_with_kernel(&mut rng, 800, model_fn, config, &mut kernel);
+
+        let decoded = decode_particles(&result, model_fn);
+        let mean: f64 = decoded.iter().map(|(x, w)| x * w).sum();
+        let var: f64 = decoded.iter().map(|(x, w)| w * (x - mean).powi(2)).sum();
+        assert!(
+            (mean - 2.4).abs() < 0.15,
+            "EV-16 posterior mean {} vs analytic 2.4",
+            mean
+        );
+        assert!(
+            (var - 0.8).abs() < 0.2,
+            "EV-16 posterior variance {} vs analytic 0.8",
+            var
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,8 @@ pub use core::model::{
 };
 pub use runtime::handler::Handler;
 pub use runtime::interpreters::{
-    PriorHandler, ReplayHandler, SafeReplayHandler, SafeScoreGivenTrace, ScoreGivenTrace,
+    score_given_trace_reconciled, PriorHandler, ReconcileReport, ReplayHandler, SafeReplayHandler,
+    SafeScoreGivenTrace, ScoreGivenTrace,
 };
 pub use runtime::trace::{Choice, ChoiceValue, Trace};
 
@@ -47,10 +48,15 @@ pub use inference::mcmc_utils::{
     DiminishingAdaptation,
 };
 pub use inference::mh::{
-    adaptive_mcmc_chain, adaptive_mcmc_chain_with_overrides, adaptive_single_site_mh, SiteProposal,
+    adaptive_mcmc_chain, adaptive_mcmc_chain_with_overrides, adaptive_single_site_mh,
+    block_regeneration_mh, SiteProposal,
 };
 pub use inference::smc::{
-    adaptive_smc, effective_sample_size, Particle, ResamplingMethod, SMCConfig,
+    adaptive_smc, adaptive_smc_with_kernel, decode_particle, decode_particles,
+    effective_sample_size, multinomial_resample, normalize_particles, rejuvenate_particles,
+    resample_particles, smc_prior_particles, stratified_resample, systematic_resample,
+    try_decode_particle, CrossoverKernel, NoKernel, Particle, PopulationKernel, ResamplingMethod,
+    SMCConfig, SMCResult,
 };
 pub use inference::validation::{
     ks_test_distribution, test_conjugate_beta_bernoulli_model, test_conjugate_normal_model,

--- a/src/runtime/interpreters.rs
+++ b/src/runtime/interpreters.rs
@@ -807,6 +807,69 @@ mod tests {
     use rand::rngs::StdRng;
     use rand::SeedableRng;
 
+    /// EA-as-PPL F3 acceptance: grafting a prefix block between two executions
+    /// of the same model, then re-scoring, yields exactly the weight a
+    /// from-scratch replay of the spliced assignment would produce — the
+    /// observable contract that "surgery + re-score" is exact.
+    #[test]
+    fn test_graft_rescore_equality() {
+        let model_fn = || {
+            sample(addr!("gene", 0), Normal::new(0.0, 1.0).unwrap()).and_then(|g0| {
+                sample(addr!("gene", 1), Normal::new(0.0, 1.0).unwrap()).and_then(move |g1| {
+                    observe(addr!("y"), Normal::new(g0 + g1, 0.5).unwrap(), 1.0)
+                        .map(move |_| (g0, g1))
+                })
+            })
+        };
+        let mut rng = StdRng::seed_from_u64(21);
+        let (_, ta) = crate::runtime::handler::run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            model_fn(),
+        );
+        let (_, tb) = crate::runtime::handler::run(
+            PriorHandler {
+                rng: &mut rng,
+                trace: Trace::default(),
+            },
+            model_fn(),
+        );
+
+        // Splice tb's "gene#0" block into ta, then re-score.
+        let mut spliced = ta.clone();
+        spliced.graft_prefix("gene\u{23}0", &tb); // "gene#0"
+        let (_, rescored) = crate::runtime::handler::run(
+            ScoreGivenTrace {
+                base: spliced,
+                trace: Trace::default(),
+            },
+            model_fn(),
+        );
+
+        // From-scratch expectation: hand-build the same assignment and score it.
+        let mut manual = Trace::default();
+        manual.insert_choice(
+            addr!("gene", 0),
+            tb.choices[&addr!("gene", 0)].value.clone(),
+            0.0,
+        );
+        manual.insert_choice(
+            addr!("gene", 1),
+            ta.choices[&addr!("gene", 1)].value.clone(),
+            0.0,
+        );
+        let (_, expected) = crate::runtime::handler::run(
+            ScoreGivenTrace {
+                base: manual,
+                trace: Trace::default(),
+            },
+            model_fn(),
+        );
+        assert!((rescored.total_log_weight() - expected.total_log_weight()).abs() < 1e-12);
+    }
+
     #[test]
     fn prior_handler_samples_and_accumulates() {
         let mut rng = StdRng::seed_from_u64(7);

--- a/src/runtime/trace.rs
+++ b/src/runtime/trace.rs
@@ -340,6 +340,72 @@ impl Trace {
         };
         self.choices.insert(addr, choice);
     }
+
+    /// Collect the addresses under `prefix` (per [`Address::has_prefix`]).
+    ///
+    /// Addresses sharing a string prefix are lexicographically contiguous, so
+    /// this scans only that range of the `BTreeMap` — O(k + log n) where k is
+    /// the number of keys sharing the raw string prefix. (The `has_prefix`
+    /// matches themselves need not be contiguous — a key like `"a0"` can sort
+    /// between `"a#1"` and `"a::b"` — hence the extra filter.)
+    fn prefix_addresses(&self, prefix: &str) -> Vec<Address> {
+        self.choices
+            .range(Address::new(prefix.to_string())..)
+            .take_while(|(a, _)| a.as_str().starts_with(prefix))
+            .filter(|(a, _)| a.has_prefix(prefix))
+            .map(|(a, _)| a.clone())
+            .collect()
+    }
+
+    /// Return a new trace containing exactly the choices whose address is under
+    /// `prefix` (per [`Address::has_prefix`]).
+    ///
+    /// **The three log accumulators of the result are zeroed and must not be
+    /// trusted**: `log_prior`/`log_likelihood`/`log_factors` are flat sums over
+    /// the whole execution (observations and factors leave no `choices` entry at
+    /// all), so they are not decomposable by address — see [`Self::insert_choice`].
+    /// Re-score the result under the relevant model
+    /// ([`ScoreGivenTrace`](crate::runtime::interpreters::ScoreGivenTrace) /
+    /// [`score_given_trace_reconciled`](crate::runtime::interpreters::score_given_trace_reconciled))
+    /// before using its weight. O(k + log n).
+    pub fn extract_prefix(&self, prefix: &str) -> Trace {
+        let mut out = Trace::default();
+        for addr in self.prefix_addresses(prefix) {
+            out.choices
+                .insert(addr.clone(), self.choices[&addr].clone());
+        }
+        out
+    }
+
+    /// Remove every choice under `prefix` in place (per [`Address::has_prefix`]).
+    ///
+    /// The log accumulators are left **stale** — they are flat, non-decomposable
+    /// sums (see [`Self::extract_prefix`]) — and must be recomputed by
+    /// re-scoring under the model. O(k + log n).
+    pub fn truncate_prefix(&mut self, prefix: &str) {
+        for addr in self.prefix_addresses(prefix) {
+            self.choices.remove(&addr);
+        }
+    }
+
+    /// Replace the block under `prefix` with the choices of `donor` that fall
+    /// under `prefix`: removes this trace's `prefix` range, then inserts the
+    /// donor's `prefix`-range choices (values and stored `logp`).
+    ///
+    /// The log accumulators are left **invalid** — the caller MUST re-score the
+    /// result under the model before using its weight. A graft that leaves the
+    /// trace structurally inconsistent with the model (e.g. an incomplete
+    /// assignment) is not detectable here; it surfaces at re-score time, so use
+    /// the reconciling re-score
+    /// ([`score_given_trace_reconciled`](crate::runtime::interpreters::score_given_trace_reconciled))
+    /// when the graft may change model structure. O(k_old + k_donor + log n).
+    pub fn graft_prefix(&mut self, prefix: &str, donor: &Trace) {
+        self.truncate_prefix(prefix);
+        for addr in donor.prefix_addresses(prefix) {
+            self.choices
+                .insert(addr.clone(), donor.choices[&addr].clone());
+        }
+    }
 }
 
 #[cfg(test)]
@@ -390,5 +456,87 @@ mod tests {
         let t = Trace::default();
         let e = t.get_f64_result(&addr!("missing")).unwrap_err();
         assert!(matches!(e, crate::error::FugueError::TraceError { .. }));
+    }
+
+    /// Boundary regression for prefix surgery: `extract_prefix("a")` must take
+    /// the descendants of `a` under the path grammar and exclude both the
+    /// sibling `ab/0` and the non-descendant `a0` that sorts inside the raw
+    /// string-prefix range.
+    #[test]
+    fn test_extract_prefix_boundary() {
+        let mut t = Trace::default();
+        for (name, v) in [
+            ("a", 0.0),
+            ("a#1", 1.0),
+            ("a/0", 2.0),
+            ("a/1/x", 3.0),
+            ("a::s", 4.0),
+            ("a0", 5.0),
+            ("ab/0", 6.0),
+        ] {
+            t.insert_choice(Address::new(name), ChoiceValue::F64(v), -0.5);
+        }
+
+        let sub = t.extract_prefix("a");
+        let got: Vec<&str> = sub.choices.keys().map(|a| a.as_str()).collect();
+        assert_eq!(got, vec!["a", "a#1", "a/0", "a/1/x", "a::s"]);
+
+        // A prefix ending in a separator matches by plain starts_with.
+        let slash = t.extract_prefix("a/");
+        let got: Vec<&str> = slash.choices.keys().map(|a| a.as_str()).collect();
+        assert_eq!(got, vec!["a/0", "a/1/x"]);
+    }
+
+    /// `graft_prefix(P, self.extract_prefix(P))` is a no-op on `choices`, and
+    /// grafting from a donor replaces exactly the `P` block.
+    #[test]
+    fn test_graft_round_trip() {
+        let mut t = Trace::default();
+        t.insert_choice(addr!("gene", 0), ChoiceValue::F64(1.0), -0.1);
+        t.insert_choice(addr!("gene", 1), ChoiceValue::F64(2.0), -0.2);
+        t.insert_choice(addr!("other"), ChoiceValue::Bool(true), -0.3);
+
+        let before: Vec<(String, ChoiceValue)> = t
+            .choices
+            .iter()
+            .map(|(a, c)| (a.as_str().to_string(), c.value.clone()))
+            .collect();
+        let block = t.extract_prefix("gene");
+        t.graft_prefix("gene", &block);
+        let after: Vec<(String, ChoiceValue)> = t
+            .choices
+            .iter()
+            .map(|(a, c)| (a.as_str().to_string(), c.value.clone()))
+            .collect();
+        assert_eq!(before, after);
+
+        // Graft from a donor with different values on the block.
+        let mut donor = Trace::default();
+        donor.insert_choice(addr!("gene", 0), ChoiceValue::F64(9.0), -0.9);
+        donor.insert_choice(addr!("gene", 1), ChoiceValue::F64(8.0), -0.8);
+        donor.insert_choice(addr!("other"), ChoiceValue::Bool(false), -0.7);
+        t.graft_prefix("gene", &donor);
+        assert_eq!(t.get_f64(&addr!("gene", 0)), Some(9.0));
+        assert_eq!(t.get_f64(&addr!("gene", 1)), Some(8.0));
+        // Non-block addresses are untouched by the graft.
+        assert_eq!(t.get_bool(&addr!("other")), Some(true));
+    }
+
+    /// Contract guard: the extracted subtrace's accumulators are zeroed —
+    /// callers must re-score before trusting any weight.
+    #[test]
+    fn test_extract_zeroes_accumulators() {
+        let mut t = Trace {
+            log_prior: -1.0,
+            log_likelihood: -2.0,
+            log_factors: -3.0,
+            ..Default::default()
+        };
+        t.insert_choice(addr!("x", 0), ChoiceValue::F64(0.5), -0.5);
+        let sub = t.extract_prefix("x");
+        assert_eq!(sub.log_prior, 0.0);
+        assert_eq!(sub.log_likelihood, 0.0);
+        assert_eq!(sub.log_factors, 0.0);
+        assert_eq!(sub.choices.len(), 1);
     }
 }

--- a/tests/f_root_exports_ea_ppl.rs
+++ b/tests/f_root_exports_ea_ppl.rs
@@ -1,0 +1,63 @@
+//! EA-as-PPL F6 acceptance: every primitive the fugue-evo inference layer
+//! consumes is importable from the crate root. This test exists so a future
+//! re-export regression fails loudly instead of breaking the downstream crate.
+
+#[allow(unused_imports)]
+use fugue::{
+    adaptive_smc, adaptive_smc_with_kernel, block_regeneration_mh, decode_particle,
+    decode_particles, effective_sample_size, multinomial_resample, normalize_particles,
+    rejuvenate_particles, resample_particles, score_given_trace_reconciled, smc_prior_particles,
+    stratified_resample, systematic_resample, try_decode_particle, CrossoverKernel, NoKernel,
+    Particle, PopulationKernel, ReconcileReport, ResamplingMethod, SMCConfig, SMCResult,
+};
+
+use fugue::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+
+/// Exercise the root-exported EA-as-PPL surface end to end: SMC with a
+/// population kernel, root-level decode, and a root-level block move.
+#[test]
+fn root_exports_are_usable() {
+    let model_fn = || {
+        sample(addr!("x", 0), Normal::new(0.0, 1.0).unwrap())
+            .and_then(|x| observe(addr!("y"), Normal::new(x, 1.0).unwrap(), 0.8).map(move |_| x))
+    };
+    let mut rng = StdRng::seed_from_u64(5);
+
+    let mut kernel = CrossoverKernel {
+        n_pairs: 10,
+        mask: Box::new(|_: &Trace, _: &Trace, _: &mut dyn rand::RngCore| vec![addr!("x", 0)]),
+    };
+    let result: SMCResult = adaptive_smc_with_kernel(
+        &mut rng,
+        50,
+        model_fn,
+        SMCConfig {
+            resampling_method: ResamplingMethod::Systematic,
+            ess_threshold: 0.5,
+            rejuvenation_steps: 1,
+        },
+        &mut kernel,
+    );
+    assert_eq!(result.len(), 50);
+    assert!(result.log_evidence.is_finite());
+
+    let decoded = decode_particles(&result, model_fn);
+    assert_eq!(decoded.len(), 50);
+    assert!(try_decode_particle(&result[0], model_fn).is_ok());
+
+    let (_, moved) =
+        block_regeneration_mh(&mut rng, model_fn, &result[0].trace, &[addr!("x", 0)], 1.0);
+    assert!(moved.total_log_weight().is_finite());
+
+    // Trace surgery + prefix predicate are part of the same surface.
+    let sub = moved.extract_prefix("x");
+    assert_eq!(sub.choices.len(), 1);
+    assert!(addr!("x", 0).has_prefix("x"));
+
+    let (_, _, report): (_, _, ReconcileReport) =
+        score_given_trace_reconciled(moved.clone(), &mut rng, model_fn()).unwrap();
+    assert!(report.fresh_addresses.is_empty());
+    assert!(report.vanished_addresses.is_empty());
+}


### PR DESCRIPTION
Implements the fugue half of the cross-repo EA-as-PPL plan. Closes the upstream work items of #44 (F1–F6); consumed by alexnodeland/fugue-evo#18.

## What's here

| Item | Change |
|---|---|
| **F1 (fix)** | `tempered_single_site_mh` now moves **non-F64 sites**: target picked uniformly over all sites, proposal dispatched by `ChoiceValue` type through the shared `propose_and_score` machinery, tempered trans-dimensional acceptance `Δlog_prior + β·Δloglik + (lq_rev − lq_fwd) + dim_term`. Previously Bool/U64/Usize-only populations (bit-string / permutation genomes) were silently frozen during rejuvenation. |
| **F2** | `block_regeneration_mh(rng, model_fn, current, block, beta)` — delete address set S, replay via `score_given_trace_reconciled`, accept with the prior-cancelling ratio incl. fresh/vanished RJMCMC bookkeeping. Fixed structure collapses to `log α = β·Δloglik`. |
| **F3** | Boundary-aware `Address::has_prefix` (`#`, `::`, `/` separators; `"gene"` ≠ prefix of `"generation"`) + `Trace::{extract_prefix, truncate_prefix, graft_prefix}`. Accumulators deliberately left invalid — re-score is the only correct recomputation (documented). |
| **F4** | `PopulationKernel<A>` (object-safe, W/T/S/E invariance contract in docs) + `NoKernel` + mask-driven `CrossoverKernel` (product-target swap Metropolis, symmetric involution ⇒ Hastings 1) + `adaptive_smc_with_kernel`. Kernel runs after intermediate resample+rejuvenation, never at terminal β=1 (FG-43). `adaptive_smc` signature unchanged, now delegates with `NoKernel`. |
| **F5** | `decode_particle` / `try_decode_particle` / `decode_particles` — replay-based return-value recovery; `Particle` stays `{trace, weight, log_weight}` (no `A: Clone` infection, FG-59 preserved). |
| **F6** | Crate-root re-exports for the full SMC primitive surface incl. previously unreachable `SMCResult`; pinned by a root-import integration test. |

## Two deliberate deviations from the plan spec (both correctness-driven)

1. **F2 has no dimension-selection term.** The plan carried `dim_term = ln|cur| − ln|prop|` over from the single-site kernel, but that term corrects for *uniform target-site selection* over a state-dependent set. `block_regeneration_mh`'s block is fixed by the caller — the forward/reverse proposal densities are fully accounted by the fresh/vanished prior terms. The trans-dimensional analytic test (Bernoulli switch gating a Normal branch, chain marginal vs. exactly marginalized posterior, ±0.03) empirically confirms the ratio.
2. **The F4 invariance test starts from the posterior, not the prior.** The spec's "prior population + crossover-only sweeps → posterior" is unsound — crossover only exchanges values between particles and cannot transport a population toward the posterior. The correct check (population sampled from the analytic posterior stays posterior-distributed under 40 sweeps) is what's implemented, alongside an end-to-end `adaptive_smc_with_kernel` evidence test.

## Validation

- 24 test suites, 0 failures; clippy & fmt clean.
- New analytic regressions: conjugate Beta-Bernoulli (validation harness), product-Normal posterior, trans-dimensional switch posterior, EV-16 Boltzmann target (prior N(0,2) + `factor(−½(x−3)²)` → mean 2.4 ± 0.15, var 0.8 ± 0.2) through the full kernel+decode path, product-invariance, bit-identical weight preservation, log-evidence non-corruption vs analytic marginal likelihood, joint-support truncation, Bool-population movement regression.

Version: `0.2.0 → 0.2.1` (all additive; no existing signature changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmWLBR9Zq6hPG5o7URDuNJ