### PR TITLE
chore(release): 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ For the initial 0.1.0 release notes, see `.github/CHANGELOG.md`.
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-08-05
+
 ### Added
 
 - **Retention thinning on the adaptive MCMC chain drivers**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "fugue-ppl"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cargo-llvm-cov",
  "clap 4.5.45",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["docs"]
 
 [package]
 name = "fugue-ppl"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 # Finding FG-51: the README previously claimed "1.70+" with nothing pinning or
 # verifying it. Verified empirically against real toolchains (not just


### PR DESCRIPTION
Cuts #47 into a release.

`publish.yml` fires on push to `main` and publishes when the manifest version is not already on crates.io, so merging this bumps `fugue-ppl` to **0.2.2** on crates.io and lets downstream crates adopt `adaptive_mcmc_chain_thinned` from the registry rather than through a `[patch.crates-io]` path override.

## Contents

- `Cargo.toml`: `0.2.1` → `0.2.2`
- `CHANGELOG.md`: the retention-thinning entry moves from `[Unreleased]` into `[0.2.2]`

No code change.

## Semver

**Minor, not breaking.** #47 added two public functions (`adaptive_mcmc_chain_thinned`, `adaptive_mcmc_chain_with_overrides_thinned`) and changed no existing signature or behaviour — verified there by cross-revision output digests on both a fixed-structure and a trans-dimensional model, which matched `main` exactly.

Suite green (24 test binaries), `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHNw2k18vFYcaTukhmvbAQ
